### PR TITLE
Minor quality of life improvements for map_manager

### DIFF
--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -4,7 +4,7 @@ project(topological_navigation)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs actionlib_msgs mongodb_store strands_navigation_msgs)
+find_package(catkin REQUIRED COMPONENTS rospy std_msgs nav_msgs sensor_msgs actionlib_msgs mongodb_store strands_navigation_msgs message_generation)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -370,7 +370,16 @@ class map_manager(object):
             rospy.logerr("Available data: "+str(available))
             return False
 
+    def generate_circle_vertices(self, radius=0.75, number=8):
+        separation_angle = 2 * math.pi / number
+        start_angle = separation_angle / 2
+        current_angle = start_angle
+        points = []
+        for i in range(0, number):
+            points.append((math.cos(current_angle) * radius, math.sin(current_angle) * radius))
+            current_angle += separation_angle
 
+        return points
 
     def add_topological_node_cb(self, req):
         return self.add_topological_node(req.name, req.pose, req.add_close_nodes)
@@ -404,7 +413,7 @@ class map_manager(object):
         node.yaw_goal_tolerance = self.yaw_goal_tolerance
         node.xy_goal_tolerance = self.xy_goal_tolerance
         node.localise_by_topic = ''
-        vertices=[(0.69, 0.287), (0.287, 0.69), (-0.287, 0.69), (-0.69, 0.287), (-0.69, -0.287), (-0.287, -0.69), (0.287, -0.69), (0.69, -0.287)]
+        vertices=self.generate_circle_vertices()
         for j in vertices :
             v = strands_navigation_msgs.msg.Vertex()
             v.x = float(j[0])

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -34,6 +34,9 @@ class map_manager(object):
             self.names=[]
             rospy.set_param('topological_map_name', self.nodes.pointset)
 
+        self.yaw_goal_tolerance = 0.1
+        self.xy_goal_tolerance = 0.3
+
 
         self.map_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
         self.last_updated = rospy.Time.now()
@@ -372,8 +375,7 @@ class map_manager(object):
     def add_topological_node_cb(self, req):
         return self.add_topological_node(req.name, req.pose, req.add_close_nodes)
 
-    def add_topological_node(self, node_name, node_pose, add_close_nodes):
-        dist = 8.0
+    def add_topological_node(self, node_name, node_pose, add_close_nodes, dist=8.0):
         #Get New Node Name
         if node_name:
             name = node_name
@@ -399,8 +401,8 @@ class map_manager(object):
         node.map = self.nodes.map
         node.pointset = self.name
         node.pose = node_pose
-        node.yaw_goal_tolerance = 0.1
-        node.xy_goal_tolerance = 0.3
+        node.yaw_goal_tolerance = self.yaw_goal_tolerance
+        node.xy_goal_tolerance = self.xy_goal_tolerance
         node.localise_by_topic = ''
         vertices=[(0.69, 0.287), (0.287, 0.69), (-0.287, 0.69), (-0.69, 0.287), (-0.69, -0.287), (-0.287, -0.69), (0.287, -0.69), (0.69, -0.287)]
         for j in vertices :
@@ -439,7 +441,7 @@ class map_manager(object):
 
     def update_node_name(self, node_name, new_name):
         if new_name in self.names:
-            return False, "node with name {0} already exists".format(req.new_name)
+            return False, "node with name {0} already exists".format(new_name)
 
         msg_store = MessageStoreProxy(collection='topological_maps')
         # The query retrieves the node name with the given name from the given pointset.


### PR DESCRIPTION
Additions:

- yaw and xy goal tolerances are no longer hardcoded in `add_topological_node` and so the defaults can be modified more easily
- vertices for the influence zone are generated by a function rather than hardcoded
- distance for determining close nodes is an optional parameter to `add_topological_node`