### PR TITLE
max_vel_trans fix for melodic

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -41,6 +41,7 @@ DYNPARAM_MAPPING = {
             'yaw_goal_tolerance': 'yaw_goal_tolerance',
             'xy_goal_tolerance': 'xy_goal_tolerance',
             'max_vel_x': 'max_vel_x',
+            'max_vel_trans' : 'max_vel_trans',
             'max_trans_vel' : 'max_trans_vel',
         },
                 
@@ -52,6 +53,7 @@ DYNPARAM_MAPPING = {
 
         'TrajectoryPlannerROS': {
             'max_vel_x': 'max_vel_x',
+            'max_vel_trans' : 'max_vel_x',
             'max_trans_vel' : 'max_vel_x',
         },
     }
@@ -191,7 +193,10 @@ class TopologicalNavServer(object):
         translation = DYNPARAM_MAPPING[key]
         for k, v in params.iteritems():
             if k in translation:
-                translated_params[translation[k]] = v
+                if rospy.has_param(translation[k]):
+                    translated_params[translation[k]] = v
+                else:
+                    rospy.logwarn('%s has no parameter %s' % (self.move_base_planner, translation[k]))
             else:
                 rospy.logwarn('%s has no dynparam translation for %s' % (self.move_base_planner, k))
         self._do_movebase_reconf(translated_params)


### PR DESCRIPTION
`max_trans_vel` is replaced by `max_vel_trans` in melodic. As of now, this parameter is reconfigured after each edge in `execute_policy_server.py`, but not in `navigate.py`. 

To make this backward compatible with `kinetic`, both `max_trans_vel` and `max_vel_trans` are configured for setting. However, as reconfiguration for all configured parameters are done in a single step, using `try... except...` might be difficult. As a temp fix, only the existing parameters will be tried to be reconfigured now. 

This may fix #10 