### PR TITLE
add missing scripts to cmakelists

### DIFF
--- a/topological_utils/CMakeLists.txt
+++ b/topological_utils/CMakeLists.txt
@@ -81,6 +81,9 @@ catkin_package(
    scripts/crop_map.py
    scripts/dummy_topological_navigation.py
    scripts/draw_predicted_map.py
+   scripts/edge_length_analysis.py
+   scripts/evaluate_predictions.py
+   scripts/insert_empty_map.py
    scripts/insert_map.py
    scripts/joy_add_node.py
    scripts/joy_add_waypoint.py
@@ -96,12 +99,14 @@ catkin_package(
    scripts/node_metadata.py
    scripts/plot_topo_map.py
    scripts/plot_yaml.py
+   scripts/print_nav_stats.py
    scripts/rm_map_from_db.py
    scripts/remove_node_tags.py
    scripts/rename_node
    scripts/tmap_from_waypoints.py
    scripts/tmap_to_yaml.py
    scripts/topological_map_update.py
+   scripts/visualise_map.py
    scripts/waypoints_to_yaml_tmap.py
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )


### PR DESCRIPTION
The release version of the package is missing some of the scripts, insert_empty_map is particularly useful.