### PR TITLE
error and preempt actionserver when a target node has invalid name

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -306,7 +306,10 @@ class TopologicalNavServer(object):
             rospy.loginfo("Navigating Take : %d", tries)
             # Everything is Awesome!!!
             # Target and Origin are Different and none of them is None
-            if (g_node is not None) and (o_node is not None) and (g_node.name != o_node.name) :
+            if (g_node is None) or (o_node is None):
+                rospy.logerr("One of the node names does not exist in the map. Aborting.")
+                break
+            elif g_node.name != o_node.name:
                 rsearch = TopologicalRouteSearch(self.lnodes)
                 route = rsearch.search_route(o_node.name, target)
                 print route


### PR DESCRIPTION
Sending a request to go to a node with a name which is not in the map would raise an exception rather than doing something about it. The if condition was not correctly checking if the nodes returned were None.

Error before:

```
[INFO] [1599657490.175769, 11371.165000]: Navigating Take : 0
[ERROR] [1599657490.176622, 11371.166000]: Exception in your execute callback: 'NoneType' object has no attribute 'name'
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/actionlib/simple_action_server.py", line 289, in executeLoop
    self.execute_callback(goal)
  File "/home/michal/robots/goals/goals_ws/src/topological_navigation/topological_navigation/scripts/navigation.py", line 246, in executeCallback
    self.navigate(goal.target)
  File "/home/michal/robots/goals/goals_ws/src/topological_navigation/topological_navigation/scripts/navigation.py", line 331, in navigate
    if(g_node.name == o_node.name) :
AttributeError: 'NoneType' object has no attribute 'name'
```

Result now:

```
[INFO] [1599657892.484037, 11734.063000]: Navigating From WayPoint1 to asdf
[INFO] [1599657892.485171, 11734.064000]: Navigating Take : 0
[ERROR] [1599657892.486047, 11734.065000]: One of the node names does not exist in the map. Aborting.
```