### PR TITLE
All functions in localisation now work with the new map type.

### DIFF
--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -151,7 +151,8 @@ class TopologicalNavLoc(object):
         """
         This function returns the distance from each waypoint to a pose in an organised way
         """
-        distances = self.get_distances_to_pose_from_tmap2(pose) if self.use_tmap2 else self.get_distances_to_pose_from_tmap1(pose)
+        distances = self.get_distances_to_pose_from_tmap1(pose) if not self.use_tmap2 else self.get_distances_to_pose_from_tmap2(pose)
+        distances = sorted(distances, key=lambda k: k['dist'])
         return distances
     
     
@@ -164,8 +165,6 @@ class TopologicalNavLoc(object):
             a['node'] = i
             a['dist'] = d
             distances.append(a)
-    
-        distances = sorted(distances, key=lambda k: k['dist'])
         
         return distances
     
@@ -179,8 +178,6 @@ class TopologicalNavLoc(object):
             a['node'] = i
             a['dist'] = d
             distances.append(a)
-    
-        distances = sorted(distances, key=lambda k: k['dist'])
         
         return distances
 
@@ -222,7 +219,7 @@ class TopologicalNavLoc(object):
                     for i in self.loc_by_topic:
                         if not_loc:
                             if not i['localise_anywhere']:      #If it should check the influence zone to localise by topic
-                                test_node=get_node(self.tmap, i['name']) if self.use_tmap2 else get_node_from_tmap2(self.tmap, i['name'])
+                                test_node=get_node(self.tmap, i['name']) if not self.use_tmap2 else get_node_from_tmap2(self.tmap, i['name'])
                                 if self.point_in_poly(test_node, msg):
                                     not_loc=False
                                     closeststr=str(i['name'])
@@ -320,7 +317,7 @@ class TopologicalNavLoc(object):
         """
         This function updates the localisation by topic variables
         """
-        self.update_loc_by_topic_from_tmap2 if self.use_tmap2 else self.update_loc_by_topic_from_tmap1
+        self.update_loc_by_topic_from_tmap1 if not self.use_tmap2 else self.update_loc_by_topic_from_tmap2
         print self.nodes_by_topic
         
         
@@ -398,6 +395,7 @@ class TopologicalNavLoc(object):
                 
             resp1 = cont(req.tag)
             tagnodes = resp1.nodes
+            
         except rospy.ServiceException, e:
             rospy.logerr("Service call failed: %s"%e)
 
@@ -460,7 +458,7 @@ class TopologicalNavLoc(object):
 
 
     def point_in_poly(self,node,pose):
-        inside = self.point_in_poly_from_tmap2(node,pose) if self.use_tmap2 else self.point_in_poly_from_tmap1(node,pose)
+        inside = self.point_in_poly_from_tmap1(node,pose) if not self.use_tmap2 else self.point_in_poly_from_tmap2(node,pose)
         return inside
     
     

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 ###################################################################################################################
-import sys, rospy, json, rostopic, tf
+import sys, json
+import rospy, rostopic, tf
 import strands_navigation_msgs.srv
 
 from actionlib_msgs.msg import *
@@ -104,8 +105,10 @@ class TopologicalNavLoc(object):
         self.cnstr="Unknown"
         
         # TODO: remove Temporary arg until tags functionality is MongoDB independent
-        self.with_tags=wtags
+        self.with_tags = wtags
         self.use_tmap2 = use_tmap2
+        if self.use_tmap2:
+            rospy.loginfo("TOPOLOGICAL LOCALISATION IS USING THE NEW MAP TYPE")
 
         self.subscribers=[]
         self.wp_pub = rospy.Publisher('closest_node', String, latch=True, queue_size=1)
@@ -124,9 +127,12 @@ class TopologicalNavLoc(object):
         self.get_tagged_srv=rospy.Service('topological_localisation/get_nodes_with_tag', strands_navigation_msgs.srv.GetTaggedNodes, self.get_nodes_wtag_cb)
         self.loc_pos_srv=rospy.Service('topological_localisation/localise_pose', strands_navigation_msgs.srv.LocalisePose, self.localise_pose_cb)
 
-        rospy.Subscriber('/topological_map', TopologicalMap, self.MapCallback)
+        if not self.use_tmap2:
+            rospy.Subscriber('/topological_map', TopologicalMap, self.MapCallback)
+        else:
+            rospy.Subscriber('/topological_map_2', String, self.MapCallback)
+            
         rospy.loginfo("Waiting for Topological map ...")
-
         while not self.rec_map :
             rospy.sleep(rospy.Duration.from_sec(0.1))
         
@@ -145,9 +151,30 @@ class TopologicalNavLoc(object):
         """
         This function returns the distance from each waypoint to a pose in an organised way
         """
+        distances = self.get_distances_to_pose_from_tmap2(pose) if self.use_tmap2 else self.get_distances_to_pose_from_tmap1(pose)
+        return distances
+    
+    
+    def get_distances_to_pose_from_tmap1(self, pose):
+        
         distances=[]
         for i in self.tmap.nodes:
             d= get_distance_node_pose(i, pose)
+            a={}
+            a['node'] = i
+            a['dist'] = d
+            distances.append(a)
+    
+        distances = sorted(distances, key=lambda k: k['dist'])
+        
+        return distances
+    
+    
+    def get_distances_to_pose_from_tmap2(self, pose):
+        
+        distances=[]
+        for i in self.tmap["nodes"]:
+            d= get_distance_node_pose_from_tmap2(i, pose)
             a={}
             a['node'] = i
             a['dist'] = d
@@ -195,7 +222,7 @@ class TopologicalNavLoc(object):
                     for i in self.loc_by_topic:
                         if not_loc:
                             if not i['localise_anywhere']:      #If it should check the influence zone to localise by topic
-                                test_node=get_node(self.tmap, i['name'])
+                                test_node=get_node(self.tmap, i['name']) if self.use_tmap2 else get_node_from_tmap2(self.tmap, i['name'])
                                 if self.point_in_poly(test_node, msg):
                                     not_loc=False
                                     closeststr=str(i['name'])
@@ -211,10 +238,11 @@ class TopologicalNavLoc(object):
     
                 if not_loc:
                     ind = 0
-                    while not_loc and ind<len(self.distances) and ind<3 :
-                        if self.distances[ind]['node'].name not in self.names_by_topic:
+                    while not_loc and ind<len(self.distances) and ind<3:
+                        name = self.distances[ind]['node'].name if not self.use_tmap2 else self.distances[ind]['node']['node']['name']
+                        if name not in self.names_by_topic:
                             if self.point_in_poly(self.distances[ind]['node'], msg) :
-                                currentstr=str(self.distances[ind]['node'].name)
+                                currentstr=str(name)
                                 closeststr=currentstr
                                 not_loc=False
                         ind+=1
@@ -223,8 +251,9 @@ class TopologicalNavLoc(object):
                     not_loc=True
                     # No go nodes and Nodes localisable by topic are ONLY closest node when the robot is within them
                     while not_loc and ind<len(self.distances) and closeststr=='none' :
-                        if self.distances[ind]['node'].name not in self.nogos and self.distances[ind]['node'].name not in self.names_by_topic :
-                            closeststr=str(self.distances[ind]['node'].name)
+                        name = self.distances[ind]['node'].name if not self.use_tmap2 else self.distances[ind]['node']['node']['name']
+                        if name not in self.nogos and name not in self.names_by_topic :
+                            closeststr=str(name)
                             not_loc=False
                         ind+=1
     
@@ -256,8 +285,13 @@ class TopologicalNavLoc(object):
         self.names_by_topic=[]
         self.nodes_by_topic=[]
         self.nogos=[]
+        #print eval(msg.data)
 
-        self.tmap = msg
+        if not self.use_tmap2:
+            self.tmap = msg
+        else:
+            self.tmap = json.loads(msg.data) 
+        
         self.rec_map=True
         self.update_loc_by_topic()
         # TODO: remove Temporary arg until tags functionality is MongoDB independent
@@ -286,6 +320,12 @@ class TopologicalNavLoc(object):
         """
         This function updates the localisation by topic variables
         """
+        self.update_loc_by_topic_from_tmap2 if self.use_tmap2 else self.update_loc_by_topic_from_tmap1
+        print self.nodes_by_topic
+        
+        
+    def update_loc_by_topic_from_tmap1(self):
+        
         for i in self.tmap.nodes:
             if i.localise_by_topic:
                 a= json.loads(i.localise_by_topic)
@@ -296,7 +336,20 @@ class TopologicalNavLoc(object):
                     a['persistency']=10
                 self.nodes_by_topic.append(a)
                 self.names_by_topic.append(a['name'])
-        print self.nodes_by_topic
+        
+        
+    def update_loc_by_topic_from_tmap2(self):
+        
+        for i in self.tmap['nodes']:
+            if i['node']['localise_by_topic']:
+                a= json.loads(i['node']['localise_by_topic'])
+                a['name'] = i['node']['name']
+                if not a.has_key('localise_anywhere'):
+                    a['localise_anywhere']=True
+                if not a.has_key('persistency'):
+                    a['persistency']=10
+                self.nodes_by_topic.append(a)
+                self.names_by_topic.append(a['name'])
 
 
     def Callback(self, msg, item):
@@ -370,15 +423,17 @@ class TopologicalNavLoc(object):
         ind = 0
         while not_loc and ind<len(distances) and ind<3 :
             if self.point_in_poly(distances[ind]['node'], req.pose) :
-                currentstr=str(distances[ind]['node'].name)
+                name = distances[ind]['node'].name if not self.use_tmap2 else distances[ind]['node']['node']['name']
+                currentstr=str(name)
                 closeststr=currentstr
                 not_loc=False
             ind+=1
 
         ind = 0
         while not_loc and ind<len(distances) :
-            if distances[ind]['node'].name not in self.nogos :
-                closeststr=str(distances[ind]['node'].name)
+            name = distances[ind]['node'].name if not self.use_tmap2 else distances[ind]['node']['node']['name']
+            if name not in self.nogos :
+                closeststr=str(name)
                 not_loc=False
             ind+=1
             
@@ -390,8 +445,13 @@ class TopologicalNavLoc(object):
         This function gets the list of No go nodes
         """
         try:
-            rospy.wait_for_service('/topological_map_manager/get_tagged_nodes', timeout=3)
-            get_prediction = rospy.ServiceProxy('/topological_map_manager/get_tagged_nodes', strands_navigation_msgs.srv.GetTaggedNodes)
+            if not self.use_tmap2:
+                rospy.wait_for_service('/topological_map_manager/get_tagged_nodes', timeout=3)
+                get_prediction = rospy.ServiceProxy('/topological_map_manager/get_tagged_nodes', strands_navigation_msgs.srv.GetTaggedNodes)
+            else:
+                rospy.wait_for_service('/topological_map_manager2/get_tagged_nodes', timeout=3)
+                get_prediction = rospy.ServiceProxy('/topological_map_manager2/get_tagged_nodes', strands_navigation_msgs.srv.GetTaggedNodes)
+                
             resp1 = get_prediction('no_go')
             return resp1.nodes
         
@@ -400,6 +460,11 @@ class TopologicalNavLoc(object):
 
 
     def point_in_poly(self,node,pose):
+        inside = self.point_in_poly_from_tmap2(node,pose) if self.use_tmap2 else self.point_in_poly_from_tmap1(node,pose)
+        return inside
+    
+    
+    def point_in_poly_from_tmap1(self,node,pose):
         
         x=pose.position.x-node.pose.position.x
         y=pose.position.y-node.pose.position.y
@@ -412,6 +477,31 @@ class TopologicalNavLoc(object):
         for i in range(n+1):
             p2x = node.verts[i % n].x
             p2y = node.verts[i % n].y
+            if y > min(p1y,p2y):
+                if y <= max(p1y,p2y):
+                    if x <= max(p1x,p2x):
+                        if p1y != p2y:
+                            xints = (y-p1y)*(p2x-p1x)/(p2y-p1y)+p1x
+                        if p1x == p2x or x <= xints:
+                            inside = not inside
+            p1x,p1y = p2x,p2y
+            
+        return inside
+    
+    
+    def point_in_poly_from_tmap2(self,node,pose):
+        
+        x=pose.position.x-node["node"]["pose"]["position"]["x"]
+        y=pose.position.y-node["node"]["pose"]["position"]["y"]
+
+        n = len(node["node"]["verts"])
+        inside = False
+
+        p1x = node["node"]["verts"][0]["x"]
+        p1y = node["node"]["verts"][0]["y"]
+        for i in range(n+1):
+            p2x = node["node"]["verts"][i % n]["x"]
+            p2y = node["node"]["verts"][i % n]["y"]
             if y > min(p1y,p2y):
                 if y <= max(p1y,p2y):
                     if x <= max(p1x,p2x):

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -317,7 +317,7 @@ class TopologicalNavLoc(object):
         """
         This function updates the localisation by topic variables
         """
-        self.update_loc_by_topic_from_tmap1 if not self.use_tmap2 else self.update_loc_by_topic_from_tmap2
+        self.update_loc_by_topic_from_tmap1() if not self.use_tmap2 else self.update_loc_by_topic_from_tmap2()
         print self.nodes_by_topic
         
         

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -15,6 +15,82 @@ from topological_navigation.tmap_utils import *
 from threading import Thread
 
 
+class LocaliseByTopicSubscriber(object):
+    """
+    Helper class for localise by topic subcription. Callable to start subsriber
+    thread.
+    """
+    def __init__(self, topic, callback, callback_args):
+        
+        self.topic = rospy.get_namespace() + topic
+        self.callback = callback
+        self.callback_args = callback_args
+        self.sub = None
+        self.t = None
+
+
+    def get_topic_type(self, topic, blocking=False):
+        """
+        Get the topic type.
+        !!! Overriden from rostopic !!!
+
+        :param topic: topic name, ``str``
+        :param blocking: (default False) block until topic becomes available, ``bool``
+
+        :returns: topic type, real topic name and fn to evaluate the message instance
+          if the topic points to a field within a topic, e.g. /rosout/msg. fn is None otherwise. ``(str, str, fn)``
+        :raises: :exc:`ROSTopicException` If master cannot be contacted
+        """
+        topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
+        if topic_type:
+            return topic_type, real_topic, msg_eval
+        elif blocking:
+            sys.stderr.write("WARNING: topic [%s] does not appear to be published yet\n"%topic)
+            while not rospy.is_shutdown():
+                topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
+                if topic_type:
+                    return topic_type, real_topic, msg_eval
+                else:
+                    rostopic._sleep(10.) # Change! Waiting for 10 seconds instead of 0.1 to reduce load
+                    
+        return None, None, None
+
+
+    def __call__(self):
+        """
+        When called start a new thread that waits for the topic type and then
+        subscribes. This is therefore non blocking and waits in the background.
+        """
+        self.t = Thread(target=self.subscribe)
+        self.t.start()
+
+
+    def subscribe(self):
+        """
+        Get the topic type and subscribe to topic. Subscriber is kept alive as
+        long as the instance of the class is alive.
+        """
+        rostopic.get_topic_type = self.get_topic_type # Monkey patch
+        topic_type = rostopic.get_topic_class(self.topic, True)[0]
+        rospy.loginfo("Subscribing to %s" % self.topic)
+        self.sub = rospy.Subscriber(
+            name=self.topic,
+            data_class=topic_type,
+            callback=self.callback,
+            callback_args=self.callback_args
+        )
+
+
+    def close(self):
+        self.sub.unregister()
+        
+
+    def __del__(self):
+        self.close()
+###################################################################################################################    
+
+
+###################################################################################################################    
 class TopologicalNavLoc(object):
 
 
@@ -347,82 +423,6 @@ class TopologicalNavLoc(object):
             
         return inside
 ###################################################################################################################        
-
-
-###################################################################################################################    
-class LocaliseByTopicSubscriber(object):
-    """
-    Helper class for localise by topic subcription. Callable to start subsriber
-    thread.
-    """
-    def __init__(self, topic, callback, callback_args):
-        
-        self.topic = rospy.get_namespace() + topic
-        self.callback = callback
-        self.callback_args = callback_args
-        self.sub = None
-        self.t = None
-
-
-    def get_topic_type(self, topic, blocking=False):
-        """
-        Get the topic type.
-        !!! Overriden from rostopic !!!
-
-        :param topic: topic name, ``str``
-        :param blocking: (default False) block until topic becomes available, ``bool``
-
-        :returns: topic type, real topic name and fn to evaluate the message instance
-          if the topic points to a field within a topic, e.g. /rosout/msg. fn is None otherwise. ``(str, str, fn)``
-        :raises: :exc:`ROSTopicException` If master cannot be contacted
-        """
-        topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
-        if topic_type:
-            return topic_type, real_topic, msg_eval
-        elif blocking:
-            sys.stderr.write("WARNING: topic [%s] does not appear to be published yet\n"%topic)
-            while not rospy.is_shutdown():
-                topic_type, real_topic, msg_eval = rostopic._get_topic_type(topic)
-                if topic_type:
-                    return topic_type, real_topic, msg_eval
-                else:
-                    rostopic._sleep(10.) # Change! Waiting for 10 seconds instead of 0.1 to reduce load
-                    
-        return None, None, None
-
-
-    def __call__(self):
-        """
-        When called start a new thread that waits for the topic type and then
-        subscribes. This is therefore non blocking and waits in the background.
-        """
-        self.t = Thread(target=self.subscribe)
-        self.t.start()
-
-
-    def subscribe(self):
-        """
-        Get the topic type and subscribe to topic. Subscriber is kept alive as
-        long as the instance of the class is alive.
-        """
-        rostopic.get_topic_type = self.get_topic_type # Monkey patch
-        topic_type = rostopic.get_topic_class(self.topic, True)[0]
-        rospy.loginfo("Subscribing to %s" % self.topic)
-        self.sub = rospy.Subscriber(
-            name=self.topic,
-            data_class=topic_type,
-            callback=self.callback,
-            callback_args=self.callback_args
-        )
-
-
-    def close(self):
-        self.sub.unregister()
-        
-
-    def __del__(self):
-        self.close()    
-###################################################################################################################
 
 
 ###################################################################################################################

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -7,7 +7,6 @@ import json
 import yaml
 import re
 import uuid
-
 import std_msgs.msg
 
 from strands_navigation_msgs.msg import *
@@ -15,7 +14,6 @@ from strands_navigation_msgs.srv import *
 from mongodb_store.message_store import MessageStoreProxy
 from topological_navigation.manager2 import map_manager_2
 from rospy_message_converter import message_converter
-
 
 
 def node_dist(node1,node2):
@@ -53,7 +51,9 @@ class map_manager(object):
         
         self.last_updated = rospy.Time.now()
         self.map_pub.publish(self.nodes)
-        self.map2_pub.publish(std_msgs.msg.String(repr(self.tmap2))) # publish new map type as a string
+        strmap = std_msgs.msg.String()
+        strmap.data = json.dumps(self.tmap2)
+        self.map2_pub.publish(strmap) # publish new map type as a string
 
         rospy.Subscriber('/update_map', std_msgs.msg.Time, self.updateCallback)
         #This service returns any given map
@@ -95,7 +95,9 @@ class map_manager(object):
         self.tmap2 = self.tmap_to_tmap2()
         self.last_updated = rospy.Time.now()
         self.map_pub.publish(self.nodes)
-        self.map2_pub.publish(std_msgs.msg.String(repr(self.tmap2))) # publish new map type as a string
+        strmap = std_msgs.msg.String()
+        strmap.data = json.dumps(self.tmap2)
+        self.map2_pub.publish(strmap) # publish new map type as a string
         self.names = self.create_list_of_nodes()
 
 

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -978,7 +978,11 @@ class map_manager(object):
             properties["xy_goal_tolerance"] = node.xy_goal_tolerance
             properties["yaw_goal_tolerance"] = node.yaw_goal_tolerance
             
-            manager2.add_node(node.name, pose, node.localise_by_topic, verts, properties)
+            req = strands_navigation_msgs.srv.GetNodeTags()
+            req.node_name = node.name
+            tags = self.get_node_tags_cb(req)[1]
+            
+            manager2.add_node(node.name, pose, node.localise_by_topic, verts, properties, tags)
             
             for edge in node.edges:
                 

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -62,8 +62,8 @@ class map_manager_2(object):
         
     def broadcast_transform(self):
         
-        trans = message_converter.convert_dictionary_to_ros_message('geometry_msgs/Vector3', self.transformation["translation"])
-        rot = message_converter.convert_dictionary_to_ros_message('geometry_msgs/Quaternion', self.transformation["rotation"])
+        trans = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Vector3", self.transformation["translation"])
+        rot = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Quaternion", self.transformation["rotation"])
         
         msg = TransformStamped()
         msg.header.stamp = rospy.Time.now()
@@ -71,6 +71,7 @@ class map_manager_2(object):
         msg.child_frame_id = self.transformation["child"]
         msg.transform.translation = trans
         msg.transform.rotation = rot
+        
         self.broadcaster.sendTransform(msg)
         
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -5,7 +5,7 @@ Created on Tue Sep 29 16:06:36 2020
 @author: Adam Binch (abinch@sagarobotics.com)
 """
 #########################################################################################################
-import rospy, tf2_ros
+import rospy, tf2_ros, datetime
 import strands_navigation_msgs.srv
 
 from geometry_msgs.msg import Vector3, Quaternion, TransformStamped
@@ -49,7 +49,7 @@ class map_manager_2(object):
             self.tmap2["pointset"] = self.pointset
             self.tmap2["transformation"] = self.transformation
             self.tmap2["meta"] = {}
-            self.tmap2["meta"]["last_updated"] = rospy.Time.now()
+            self.tmap2["meta"]["last_updated"] = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
             self.tmap2["nodes"] = []
         else:
             self.name = tmap2["name"]

--- a/topological_navigation/src/topological_navigation/tmap_utils.py
+++ b/topological_navigation/src/topological_navigation/tmap_utils.py
@@ -14,6 +14,14 @@ def get_node(top_map, node_name):
             return i
     return None
 
+
+def get_node_from_tmap2(top_map, node_name):
+    for i in top_map["nodes"]:
+        if i["node"]["name"] == node_name:
+            return i
+    return None
+
+
 """
     get_distance
     
@@ -35,7 +43,11 @@ def get_distance_node_pose(node, pose):
     dist=math.hypot((pose.position.x-node.pose.position.x),(pose.position.y-node.pose.position.y))
     return dist
 
- 
+
+def get_distance_node_pose_from_tmap2(node, pose):
+    dist=math.hypot((pose.position.x-node["node"]["pose"]["position"]["x"]),(pose.position.y-node["node"]["pose"]["position"]["y"]))
+    return dist
+
 """
     get_distance_to_node
     


### PR DESCRIPTION
This includes its services.
To localise using the new map type pass the arg `-use_tmap2` i.e. `rosrun topological_navigation localisation.py -use_tmap2`
Robot localises in the topological map using the topological map to baselink tf transform.
When an old map is loaded in the map manager, it is automatically converted to the new type and the default identity transform between the topomap and the map is broadcast.