### PR TITLE
Base frame used by localisation is no longer hard coded (in toponav 2).

### DIFF
--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -134,7 +134,7 @@ include_directories(
    scripts/manual_edge_predictions.py
    scripts/speed_based_prediction.py
    scripts/reconf_at_edges_server.py
-   scripts/TopologicalTransformPublisher.py
+   scripts/topological_transform_publisher.py
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )
 

--- a/topological_navigation/scripts/TopologicalTransformPublisher.py
+++ b/topological_navigation/scripts/TopologicalTransformPublisher.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""
+Created on Fri Feb 26 10:37:50 2021
+
+@author: Adam Binch (abinch@sagarobotics.com)
+"""
+#########################################################################################################
+import rospy, json
+from std_msgs.msg import String
+from geometry_msgs.msg import Vector3, Quaternion, TransformStamped
+from rospy_message_converter import message_converter
+
+
+class TopologicalTransformPublisher(object):
+    
+    
+    def __init__(self):
+        
+        self.rec_map=False
+        
+        self.transform_pub = rospy.Publisher("/topological_transform", TransformStamped, latch=True, queue_size=1)
+        
+        rospy.Subscriber('/topological_map_2', String, self.map_callback)
+        
+        rospy.loginfo("Waiting for Topological map ...")
+        while not self.rec_map :
+            rospy.sleep(rospy.Duration.from_sec(0.1))
+            
+        rospy.spin()
+    
+    
+    def map_callback(self, msg):
+        
+        self.tmap = json.loads(msg.data) 
+        self.rec_map=True
+        
+        rospy.loginfo("Topological map received")
+        
+        self.publish_transform()
+        
+        
+    def publish_transform(self):
+        
+        transformation = self.tmap["transformation"]
+        
+        trans = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Vector3", transformation["translation"])
+        rot = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Quaternion", transformation["rotation"])
+        
+        msg = TransformStamped()
+        msg.header.stamp = rospy.Time.now()
+        msg.header.frame_id = transformation["parent"]
+        msg.child_frame_id = transformation["child"]
+        msg.transform.translation = trans
+        msg.transform.rotation = rot
+        
+        self.transform_pub.publish(msg)
+#########################################################################################################
+
+
+#########################################################################################################
+if __name__ == '__main__':
+    
+    rospy.init_node("topological_transform_publisher")
+    
+    TopologicalTransformPublisher()
+#########################################################################################################

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -4,13 +4,8 @@ import sys, json
 import rospy, rostopic, tf
 import strands_navigation_msgs.srv
 
-from actionlib_msgs.msg import *
-from move_base_msgs.msg import *
 from geometry_msgs.msg import Pose
 from std_msgs.msg import String
-
-from strands_navigation_msgs.msg import TopologicalNode
-from strands_navigation_msgs.msg import TopologicalMap
 
 from topological_navigation.tmap_utils import *
 from threading import Thread
@@ -133,7 +128,10 @@ class TopologicalNavLoc(object):
         rospy.loginfo("NODES BY TOPIC: %s" %self.names_by_topic)
         rospy.loginfo("NO GO NODES: %s" %self.nogos)
         
-        rospy.loginfo("Listening to topo_map to base_link tf transform")
+        self.base_frame = rospy.get_param("~base_frame", "base_link")
+        self.tmap_frame = self.tmap["transformation"]["child"]
+        
+        rospy.loginfo("Listening to the tf transform between {} and {}".format(self.tmap_frame, self.base_frame))
         self.listener = tf.TransformListener()
         self.rate = rospy.Rate(10.0)
         self.PoseCallback()
@@ -166,8 +164,8 @@ class TopologicalNavLoc(object):
             
             try:
                 now = rospy.Time(0)
-                self.listener.waitForTransform("topo_map", "base_link", now, rospy.Duration(2.0))
-                (trans,rot) = self.listener.lookupTransform("topo_map", "base_link", now)
+                self.listener.waitForTransform(self.tmap_frame, self.base_frame, now, rospy.Duration(2.0))
+                (trans,rot) = self.listener.lookupTransform(self.tmap_frame, self.base_frame, now)
             except Exception as e:
                 rospy.logerr(e)
                 self.rate.sleep()

--- a/topological_navigation/scripts/topological_transform_publisher.py
+++ b/topological_navigation/scripts/topological_transform_publisher.py
@@ -9,58 +9,60 @@ import rospy, json
 from std_msgs.msg import String
 from geometry_msgs.msg import Vector3, Quaternion, TransformStamped
 from rospy_message_converter import message_converter
+import tf2_ros
 
 
 class TopologicalTransformPublisher(object):
-    
-    
+    """This class defines a tf publisher that publishes the transformation
+    between parent and child frames of a topological_map_2.
+    """
     def __init__(self):
-        
+
         self.rec_map=False
-        
-        self.transform_pub = rospy.Publisher("/topological_transform", TransformStamped, latch=True, queue_size=1)
-        
+
+        self.broadcaster = tf2_ros.StaticTransformBroadcaster()
+
         rospy.Subscriber('/topological_map_2', String, self.map_callback)
-        
+
         rospy.loginfo("Waiting for Topological map ...")
         while not self.rec_map :
             rospy.sleep(rospy.Duration.from_sec(0.1))
-            
-        rospy.spin()
-    
-    
+
+
     def map_callback(self, msg):
-        
-        self.tmap = json.loads(msg.data) 
+
+        self.tmap = json.loads(msg.data)
         self.rec_map=True
-        
+
         rospy.loginfo("Topological map received")
-        
+
         self.publish_transform()
-        
-        
+
+
     def publish_transform(self):
-        
+
         transformation = self.tmap["transformation"]
-        
+
         trans = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Vector3", transformation["translation"])
         rot = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Quaternion", transformation["rotation"])
-        
+
         msg = TransformStamped()
         msg.header.stamp = rospy.Time.now()
         msg.header.frame_id = transformation["parent"]
         msg.child_frame_id = transformation["child"]
         msg.transform.translation = trans
         msg.transform.rotation = rot
-        
-        self.transform_pub.publish(msg)
+
+        self.broadcaster.sendTransform(msg)
+
 #########################################################################################################
 
 
 #########################################################################################################
 if __name__ == '__main__':
-    
+
     rospy.init_node("topological_transform_publisher")
-    
+
     TopologicalTransformPublisher()
+    rospy.spin()
 #########################################################################################################


### PR DESCRIPTION
It is set by a rosparam `topological_localisation/base_frame` (default=`base_link`).
topomap frame is retrieved from the topological map.

Includes a new node `topological_transform_publisher` for publishing the map to topomap transform on the topic `/topological_transform` with msg type `geometry_msgs/TransformStamped`

removed unused imports from localisation.