### PR TITLE
Fixed move_base rosparam missing for topological navigation

### DIFF
--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -12,6 +12,7 @@
 	<arg name="machine" default="localhost" />
 	<arg name="user" default="" />
 	<arg name="move_base_reconf_service" default="DWAPlannerROS" />
+  	<arg name="move_base_planner" default="move_base/DWAPlannerROS" />
 
 	<machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
 
@@ -33,10 +34,12 @@
 	<node pkg="topological_navigation" name="topological_navigation" type="navigation.py" output="screen" respawn="true">
 		<param name="retries" type="int" value="$(arg topological_navigation_retries)"/>
 		<param name="move_base_reconf_service" type="str" value="$(arg move_base_reconf_service)"/>
+		<param name="move_base_planner" type="str" value="$(arg move_base_planner)"/>
 	</node>
 	<node pkg="topological_navigation" name="execute_policy_server" type="execute_policy_server.py" output="screen" respawn="true">
 		<param name="retries" type="int" value="$(arg execute_policy_retries)"/>
 		<param name="move_base_reconf_service" type="str" value="$(arg move_base_reconf_service)"/>
+		<param name="move_base_planner" type="str" value="$(arg move_base_planner)"/>
 	</node>
 
 	<node pkg="topological_navigation" type="navstats_loger.py" name="topological_navstats_logger" respawn="true" unless="$(arg load_map_from_file)"/>

--- a/topological_navigation/scripts/execute_policy_server.py
+++ b/topological_navigation/scripts/execute_policy_server.py
@@ -193,7 +193,7 @@ class PolicyExecutionServer(object):
         """
         Creates the dynamic reconfigure clients for the given actions
         """
-        rcnfsrvrname= rospy.get_namespace() + mb_action +'/' + self.move_base_planner
+        rcnfsrvrname= rospy.get_namespace() + mb_action +'/' + self.move_base_reconf_service
         test_service = rcnfsrvrname+'/set_parameters'
 
         service_created = False
@@ -212,7 +212,7 @@ class PolicyExecutionServer(object):
                     rospy.logwarn("I couldn't create reconfigure client %s. remaining tries %d" % (rcnfsrvrname,service_created_tries))
                     rospy.sleep(1)
                 else:
-                    rospy.logerr("I couldn't create reconfigure client %s. is %s running?" % (rcnfsrvrname, i))
+                    rospy.logerr("I couldn't create reconfigure client %s. is %s running?" % (rcnfsrvrname, rcnfsrvrname))
         return False
 
 


### PR DESCRIPTION
Hi, the current code is not setting the correct move_base rosparam required for navigating between waypoints. The navigation does work if the robot uses `DWAPlannerROS` as planner but it doesn't if, for example, we are using `TrajectoryPlannerROS`. I checked that this has been fixed in the Rasberry code but not in the current package.