### PR TITLE
Nodes and edges have two restrictions fields, one for planning restrictions and one for runtime restrictions.

### DIFF
--- a/topological_navigation_msgs/srv/UpdateRestrictions.srv
+++ b/topological_navigation_msgs/srv/UpdateRestrictions.srv
@@ -1,5 +1,6 @@
-string name
-string restrictions   # boolean sentence
+string name                    # node name or edge id
+string restrictions_planning   # boolean sentence
+string restrictions_runtime    # boolean sentence
 ---
 bool success
 string message

--- a/topological_navigation_msgs/srv/UpdateRestrictions.srv
+++ b/topological_navigation_msgs/srv/UpdateRestrictions.srv
@@ -1,6 +1,7 @@
 string name                    # node name or edge id
 string restrictions_planning   # boolean sentence
 string restrictions_runtime    # boolean sentence
+bool update_edges              # if updating node restrictions then apply planning restrictions to edges involving the node
 ---
 bool success
 string message


### PR DESCRIPTION
Both are boolean sentences (default="True")
Update restrictions services modified to account for this.

If updating node restrictions then apply planning restrictions to edges involving the node.
Set this behaviour with new boolean arg `update_edges` in srv for updating a node's restrictions

