### PR TITLE
Topological navigation can handle any type of goal.

### DIFF
--- a/topological_navigation/CMakeLists.txt
+++ b/topological_navigation/CMakeLists.txt
@@ -127,8 +127,8 @@ include_directories(
    scripts/navigation.py
    scripts/visualise_map.py
    scripts/map_manager.py
+   scripts/map_manager2.py
    scripts/travel_time_estimator.py
-   scripts/execute_policy_server.py
    scripts/topological_prediction.py
    scripts/get_simple_policy.py
    scripts/manual_edge_predictions.py

--- a/topological_navigation/package.xml
+++ b/topological_navigation/package.xml
@@ -39,7 +39,6 @@
   <run_depend>mongodb_store</run_depend>
   <run_depend>strands_navigation_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
-  <run_depend>monitored_navigation</run_depend>
   <run_depend>dwa_local_planner</run_depend>
   <run_depend>fremenserver</run_depend>
   <run_depend>rospy_message_converter</run_depend>

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -149,15 +149,15 @@ class TopologicalNavServer(object):
 
     def reconf_movebase(self, cedg, cnode, intermediate):
 
-        if cnode["properties"]["xy_goal_tolerance"] <= 0.1:
+        if cnode["node"]["properties"]["xy_goal_tolerance"] <= 0.1:
             cxygtol = 0.1
         else:
-            cxygtol = cnode["properties"]["xy_goal_tolerance"]
+            cxygtol = cnode["node"]["properties"]["xy_goal_tolerance"]
         if not intermediate:
-            if cnode["properties"]["yaw_goal_tolerance"] <= 0.087266:
+            if cnode["node"]["properties"]["yaw_goal_tolerance"] <= 0.087266:
                 cytol = 0.087266
             else:
-                cytol = cnode["properties"]["yaw_goal_tolerance"]
+                cytol = cnode["node"]["properties"]["yaw_goal_tolerance"]
         else:
             cytol = 6.283
 
@@ -359,7 +359,7 @@ class TopologicalNavServer(object):
             # Target and Origin are not None
             if g_node is not None and o_node is not None:
                 rsearch = TopologicalRouteSearch2(self.lnodes)
-                route = rsearch.search_route(o_node["name"], target)
+                route = rsearch.search_route(o_node["node"]["name"], target)
                 route = self.enforce_navigable_route(route, target)
                 print route
                 
@@ -448,7 +448,7 @@ class TopologicalNavServer(object):
             rospy.logerr("Failed to get edge from id!! Invalid route!!")
             return False, inc
 
-        inf = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", o_node["pose"])
+        inf = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", o_node["node"]["pose"])
 
         # If the robot is not on a node or the first action is not move base type
         # navigate to closest node waypoint (only when first action is not move base)
@@ -524,7 +524,7 @@ class TopologicalNavServer(object):
             self.stat = nav_stats(route.source[rindex], cedg["node"], self.topol_map, cedg["edge_id"])
             dt_text = self.stat.get_start_time_str()
             
-            inf = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", cnode["pose"])
+            inf = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", cnode["node"]["pose"])
 
             if self.edge_reconfigure:
                 self.edgeReconfigureManager.register_edge(cedg)

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -647,6 +647,7 @@ class TopologicalNavServer(object):
                     self.preempted = True
             else:
                 result = True
+                self.edge_action_manager.client.cancel_all_goals()
 
         if not res:
             if not result:

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -516,12 +516,13 @@ class TopologicalNavServer(object):
 
             if self.edge_reconfigure:
                 self.edgeReconfigureManager.register_edge(cedg)
-                self.edgeReconfigureManager.initialise()
-                self.edgeReconfigureManager.reconfigure()
+                if self.edgeReconfigureManager.active:
+                    self.edgeReconfigureManager.initialise()
+                    self.edgeReconfigureManager.reconfigure()
 
             nav_ok, inc = self.execute_action(cedg, cnode)
 
-            if self.edge_reconfigure:
+            if self.edge_reconfigure and self.edgeReconfigureManager.active:
                 self.edgeReconfigureManager._reset()
                 rospy.sleep(rospy.Duration.from_sec(0.3))
 

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -280,7 +280,7 @@ class TopologicalNavServer(object):
         if self.current_node != msg.data:  # is there any change on this topic?
             self.current_node = msg.data  # we are at this new node
             if msg.data != "none":  # are we at a node?
-                rospy.loginfo("new node reached %s", self.current_node)
+                rospy.loginfo("new node reached: {}".format(self.current_node))
                 if self.navigation_activated:  # is the action server active?
                     if self.stat:
                         self.stat.set_at_node()
@@ -304,14 +304,14 @@ class TopologicalNavServer(object):
         succeeded, inc = self.followRoute(route, target, 1)
 
         if succeeded:
-            rospy.loginfo("navigation finished successfully")
+            rospy.loginfo("Navigation Finished Successfully")
             self.publish_feedback_exec_policy(GoalStatus.SUCCEEDED)
         else:
             if self.cancelled:
-                rospy.loginfo("Fatal fail")
+                rospy.loginfo("Fatal Fail")
                 self.publish_feedback_exec_policy(GoalStatus.PREEMPTED)
             else:
-                rospy.loginfo("navigation failed")
+                rospy.loginfo("Navigation Failed")
                 self.nfails += 1
                 if self.nfails >= self.n_tries:
                     self.publish_feedback_exec_policy(GoalStatus.ABORTED)
@@ -542,13 +542,13 @@ class TopologicalNavServer(object):
 
             if nav_ok:
                 self.stat.status = "success"
-                rospy.loginfo("navigation finished on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
+                rospy.loginfo("Navigation Finished on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
             else:
                 if not_fatal:
-                    rospy.loginfo("navigation failed on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
+                    rospy.loginfo("Navigation Failed on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
                     self.stat.status = "failed"
                 else:
-                    rospy.loginfo("Fatal fail on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
+                    rospy.loginfo("Fatal Fail on %s (%d/%d)" % (dt_text, operation_time, time_to_wp))
                     self.stat.status = "fatal"
 
             self.publish_stats()

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -27,7 +27,6 @@ from topological_navigation.edge_action_manager import EdgeActionManager
 from topological_navigation.edge_reconfigure_manager import EdgeReconfigureManager
 
 from copy import deepcopy
-from rospy_message_converter import message_converter
 
 # A list of parameters topo nav is allowed to change and their mapping from dwa speak.
 # If not listed then the param is not sent, e.g. TrajectoryPlannerROS doesn't have tolerances.

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -16,10 +16,18 @@ def _import(location, object_name):
 
 
 class dict_tools(object):
+                
+                
+    def get_paths_from_nested_dict(self, nested):
+        paths = list(self.nested_dict_iter(nested))
+        return [{"keys": item[0], "value": item[1]} for item in paths]
     
     
     def nested_dict_iter(self, nested, prefix=""):
-        
+        """
+        Recursively loops through a nested dictionary. 
+        For each inner-most value generates the list of keys needed to access it.
+        """
         for key, value in nested.iteritems():
             path = "{},{}".format(prefix, key)
             if isinstance(value, collections.Mapping):
@@ -33,7 +41,7 @@ class dict_tools(object):
         return reduce(operator.getitem, mapList, dataDict)
 
 
-    def setInDict(self, dataDict, mapList, value):
+    def setInDict(self, dataDict, mapList, value):     
         self.getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
         return dataDict
 #########################################################################################################
@@ -71,16 +79,16 @@ class EdgeActionManager(object):
     def construct_goal(self, action_type, goal_args):
         
         dt = dict_tools()
-        paths = list(dt.nested_dict_iter(goal_args))
+        paths = dt.get_paths_from_nested_dict(goal_args)
         
-        for path in paths:
-            keys = path[0]
-            value = path[1]
+        for item in paths:
+            keys = item["keys"]
+            value = item["value"]
         
             if isinstance(value, str) and value.startswith("$"):
                 _property = dt.getFromDict(self.destination_node, value[1:].split("."))
                 goal_args = dt.setInDict(goal_args, keys, _property)
-        
+
         self.goal = message_converter.convert_dictionary_to_ros_message(action_type, goal_args)
         
         

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -100,18 +100,7 @@ class EdgeActionManager(object):
     def execute(self):
         
         rospy.loginfo("Edge Action Manager: Executing the action")
-        self.client.send_goal(self.goal, self.execute_callback)
+        self.client.send_goal(self.goal)
         
         rospy.loginfo("Edge Action Manager: Waiting for the result ...")
-        self.client.wait_for_result()
-    
-
-    def execute_callback(self, status, result):
-        
-        if status == 3:
-            rospy.loginfo("Edge Action Manager: Succeeded")
-        elif status == 2 or status == 6:
-            rospy.logwarn("Edge Action Manager: Preempted")
-        elif status != 3:
-            rospy.logerr("Edge Action Manager: Failed")    
 #########################################################################################################

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+Created on Tue Apr 13 22:02:24 2021
+@author: Adam Binch (abinch@sagarobotics.com)
+
+"""
+#########################################################################################################
+import rospy, actionlib
+
+
+class EdgeActionManager(object):
+    
+    
+    def __init__(self, edge):
+        
+        self.client_created = False
+        
+        action_type = edge["action_type"]
+        action_name = edge["action"]
+        
+        items = action_type.split("/")
+        package = items[0]
+        goal_spec = items[1]
+        action_spec = items[1][:-4] + "Action"
+        
+        action = self._import(package, action_spec)
+        goal = self._import(package, goal_spec)
+        
+        rospy.loginfo("Edge Action Manager: Creating {} client with {} imported from {}.msg ...".format(action_name, action_spec, package))
+        
+        action_client = actionlib.SimpleActionClient(action_name, action)        
+        self.client_created = action_client.wait_for_server(rospy.Duration(5.0))
+        
+        if self.client_created:
+            rospy.loginfo("Edge Action Manager: Client created")
+        else:
+            rospy.logerr("Edge Action Manager: Client not created")
+            
+    
+    def _import(self, package, object_name):
+        mod = __import__(package + ".msg", fromlist=[object_name]) 
+        return getattr(mod, object_name) 
+#########################################################################################################

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -5,7 +5,9 @@ Created on Tue Apr 13 22:02:24 2021
 
 """
 #########################################################################################################
-import rospy, actionlib, operator, collections, json
+import rospy, actionlib
+import operator, collections, json
+
 from functools import reduce  # forward compatibility for Python 3
 from rospy_message_converter import message_converter
 
@@ -53,6 +55,8 @@ class EdgeActionManager(object):
     
     def __init__(self, edge, destination_node):
         
+        self.client_created = False
+        
         self.edge = eval(json.dumps(edge)) # remove unicode prefix notation u
         self.destination_node = eval(json.dumps(destination_node))
         
@@ -74,6 +78,7 @@ class EdgeActionManager(object):
         rospy.loginfo("Edge Action Manager: Creating a {} client".format(action_name))
         self.client = actionlib.SimpleActionClient(action_name, action)        
         self.client.wait_for_server()
+        self.client_created = True
         
         
     def construct_goal(self, action_type, goal_args):

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -5,13 +5,41 @@ Created on Tue Apr 13 22:02:24 2021
 
 """
 #########################################################################################################
-import rospy, actionlib
-from rospy_message_converter import message_converter
-import operator
-from copy import deepcopy
+import rospy, actionlib, operator, collections
 from functools import reduce  # forward compatibility for Python 3
+from rospy_message_converter import message_converter
 
 
+def _import(location, object_name):
+    mod = __import__(location, fromlist=[object_name]) 
+    return getattr(mod, object_name) 
+
+
+class dict_tools(object):
+    
+    
+    def nested_dict_iter(self, nested, prefix=""):
+        
+        for key, value in nested.iteritems():
+            path = "{},{}".format(prefix, key)
+            if isinstance(value, collections.Mapping):
+                for inner_key, inner_value in self.nested_dict_iter(value, path):
+                    yield inner_key, inner_value
+            else:
+                yield path[1:].split(","), value
+    
+    
+    def getFromDict(self, dataDict, mapList):
+        return reduce(operator.getitem, mapList, dataDict)
+
+
+    def setInDict(self, dataDict, mapList, value):
+        self.getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
+        return dataDict
+#########################################################################################################
+
+
+#########################################################################################################
 class EdgeActionManager(object):
     
     
@@ -30,52 +58,30 @@ class EdgeActionManager(object):
         action_spec = items[1][:-4] + "Action"
         
         rospy.loginfo("Edge Action Manager: Importing {} from {}.msg".format(action_spec, package))
-        action = self._import(package + ".msg", action_spec)
+        action = _import(package + ".msg", action_spec)
+        
+        rospy.loginfo("Edge Action Manager: Constructing the goal")
+        self.construct_goal(action_type, edge["goal"])
         
         rospy.loginfo("Edge Action Manager: Creating a {} client".format(self.action_name))
         self.client = actionlib.SimpleActionClient(self.action_name, action)        
         self.client.wait_for_server()
         
-        rospy.loginfo("Edge Action Manager: Constructing the goal")
-        self.construct_goal(action_type, edge["goal"])
-        
-        
-    def _import(self, location, object_name):
-        mod = __import__(location, fromlist=[object_name]) 
-        return getattr(mod, object_name) 
-        
         
     def construct_goal(self, action_type, goal_args):
         
-        goal_args_cpy = deepcopy(goal_args)
-        stack = list(goal_args_cpy.items()) 
+        dt = dict_tools()
+        paths = list(dt.nested_dict_iter(goal_args))
         
-        visited = set() 
-        keys = []
-        while stack: 
-            k, v = stack.pop() 
-            if isinstance(v, dict): 
-                keys.append(k)
-                if k not in visited: 
-                    stack.extend(v.items()) 
-            else:
-                keys.append(k)
-                if isinstance(v, str) and v.startswith("$"):
-                    _property = self.getFromDict(self.destination_node, v[1:].split("."))
-                    self.setInDict(goal_args, keys, _property)
-                
-                keys = [keys[0]]
-            visited.add(k)
+        for path in paths:
+            keys = path[0]
+            value = path[1]
+        
+            if isinstance(value, str) and value.startswith("$"):
+                _property = dt.getFromDict(self.destination_node, value[1:].split("."))
+                goal_args = dt.setInDict(goal_args, keys, _property)
         
         self.goal = message_converter.convert_dictionary_to_ros_message(action_type, goal_args)
-        
-        
-    def getFromDict(self, dataDict, mapList):
-        return reduce(operator.getitem, mapList, dataDict)
-
-
-    def setInDict(self, dataDict, mapList, value):
-        self.getFromDict(dataDict, mapList[:-1])[mapList[-1]] = value
         
         
     def execute(self):

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -13,8 +13,6 @@ class EdgeActionManager(object):
     
     def __init__(self, edge):
         
-        self.client_created = False
-        
         action_type = edge["action_type"]
         action_name = edge["action"]
         
@@ -23,18 +21,20 @@ class EdgeActionManager(object):
         goal_spec = items[1]
         action_spec = items[1][:-4] + "Action"
         
+        rospy.loginfo("Edge Action Manager: Importing {} from {}.msg".format(action_spec, package))
+        
         action = self._import(package, action_spec)
         goal = self._import(package, goal_spec)
         
-        rospy.loginfo("Edge Action Manager: Creating {} client with {} imported from {}.msg ...".format(action_name, action_spec, package))
+        rospy.loginfo("Edge Action Manager: Creating {} client ...".format(action_name))
         
         action_client = actionlib.SimpleActionClient(action_name, action)        
-        self.client_created = action_client.wait_for_server(rospy.Duration(5.0))
+        action_client.wait_for_server()
         
-        if self.client_created:
-            rospy.loginfo("Edge Action Manager: Client created")
-        else:
-            rospy.logerr("Edge Action Manager: Client not created")
+        rospy.loginfo("Edge Action Manager: Client created")
+        print action_client.get_state()
+        res = action_client.get_result()
+
             
     
     def _import(self, package, object_name):

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -72,13 +72,13 @@ class EdgeActionManager(object):
         rospy.loginfo("Edge Action Manager: Importing {} from {}.msg".format(action_spec, package))
         action = _import(package + ".msg", action_spec)
         
-        rospy.loginfo("Edge Action Manager: Constructing the goal")
-        self.construct_goal(action_type, self.edge["goal"])
-        
         rospy.loginfo("Edge Action Manager: Creating a {} client".format(action_name))
         self.client = actionlib.SimpleActionClient(action_name, action)        
         self.client.wait_for_server()
         self.client_created = True
+        
+        rospy.loginfo("Edge Action Manager: Constructing the goal")
+        self.construct_goal(action_type, self.edge["goal"])
         
         
     def construct_goal(self, action_type, goal_args):

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -6,38 +6,81 @@ Created on Tue Apr 13 22:02:24 2021
 """
 #########################################################################################################
 import rospy, actionlib
+from rospy_message_converter import message_converter
+from collections import namedtuple
+from copy import deepcopy
 
 
 class EdgeActionManager(object):
     
     
-    def __init__(self, edge):
+    def __init__(self, edge, destination_node, frame_id="map"):
+        
+        rospy.loginfo("Edge Action Manager: Processing edge {} ...".format(edge["edge_id"]))
+        
+        self.edge = edge
+        self.destination_node = destination_node
+        self.frame_id = frame_id
         
         action_type = edge["action_type"]
-        action_name = edge["action"]
+        self.action_name = edge["action"]
         
         items = action_type.split("/")
         package = items[0]
-        goal_spec = items[1]
         action_spec = items[1][:-4] + "Action"
         
         rospy.loginfo("Edge Action Manager: Importing {} from {}.msg".format(action_spec, package))
+        action = self._import(package + ".msg", action_spec)
         
-        action = self._import(package, action_spec)
-        goal = self._import(package, goal_spec)
+        rospy.loginfo("Edge Action Manager: Creating a {} client".format(self.action_name))
+        self.client = actionlib.SimpleActionClient(self.action_name, action)        
+        self.client.wait_for_server()
         
-        rospy.loginfo("Edge Action Manager: Creating {} client ...".format(action_name))
+        rospy.loginfo("Edge Action Manager: Constructing the goal")
+        self.construct_goal(action_type, edge["goal"])
         
-        action_client = actionlib.SimpleActionClient(action_name, action)        
-        action_client.wait_for_server()
         
-        rospy.loginfo("Edge Action Manager: Client created")
-        print action_client.get_state()
-        res = action_client.get_result()
-
-            
-    
-    def _import(self, package, object_name):
-        mod = __import__(package + ".msg", fromlist=[object_name]) 
+    def _import(self, _file, object_name):
+        mod = __import__(_file, fromlist=[object_name]) 
         return getattr(mod, object_name) 
+        
+        
+    def construct_goal(self, action_type, goal_args):
+        
+        node_dict = deepcopy(self.destination_node)
+        
+        # pose field of node modified to match a geometry_msgs/PoseStamped msg
+        node_dict["pose"] = {"pose": node_dict["pose"]}
+        node_dict["pose"]["header"] = {}
+        node_dict["pose"]["header"]["frame_id"] = self.frame_id
+        
+        node = namedtuple("Node", node_dict.keys())(*node_dict.values())
+        
+        for arg in goal_args.keys():
+            value = deepcopy(goal_args[arg])
+            if type(value) is str and value.startswith("$node"):
+                goal_args[arg] = eval(value[1:]) 
+        
+        self.goal = message_converter.convert_dictionary_to_ros_message(action_type, goal_args)
+        
+        
+    def execute(self):
+        
+        rospy.loginfo("Edge Action Manager: Executing the action")
+        self.client.send_goal(self.goal, self.execute_callback)
+        
+        rospy.loginfo("Edge Action Manager: Waiting for the result ...")
+        self.client.wait_for_result()
+        
+        return self.client.get_result()
+    
+
+    def execute_callback(self, status, result):
+        
+        if status == 3:
+            rospy.loginfo("Edge Action Manager: Succeeded")
+        elif status == 2 or status == 6:
+            rospy.logwarn("Edge Action Manager: Preempted")
+        elif status != 3:
+            rospy.logerr("Edge Action Manager: Failed")    
 #########################################################################################################

--- a/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
@@ -48,16 +48,17 @@ class EdgeReconfigureManager(object):
             client = dynamic_reconfigure.client.Client(namespace, timeout=2.0)
             try:
                 config = client.get_configuration()
-                self.initial_config[namespace] = {}
-                self.edge_config[namespace] = {}
-
-                for param in self.edge["config"]:
-                    if param["namespace"] == namespace:
-                        self.initial_config[namespace][param["name"]] = config[param["name"]]
-                        self.edge_config[namespace][param["name"]] = param["value"]
-
             except rospy.ServiceException as e:
                 rospy.logwarn("Edge Reconfigure Manager: Caught service exception: {}".format(e))
+                continue
+                
+            self.initial_config[namespace] = {}
+            self.edge_config[namespace] = {}
+
+            for param in self.edge["config"]:
+                if param["namespace"] == namespace:
+                    self.initial_config[namespace][param["name"]] = config[param["name"]]
+                    self.edge_config[namespace][param["name"]] = param["value"]
                 
         
     def reconfigure(self):

--- a/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
@@ -16,6 +16,8 @@ class EdgeReconfigureManager(object):
         
         rospy.logwarn("Edge Reconfigure Manager: USING EDGE RECONFIGURE ...")
         
+        self.active = False
+        
         self.edge = {}
         self.initial_config = {}                    
         self.edge_config = {}
@@ -27,6 +29,7 @@ class EdgeReconfigureManager(object):
         
     def register_edge(self, edge):
         
+        self.active = False
         self.edge = edge
         
         namespaces = []
@@ -35,6 +38,7 @@ class EdgeReconfigureManager(object):
             
         self.namespaces = list(set(namespaces))
         if self.namespaces:
+            self.active = True
             rospy.loginfo("Edge Reconfigure Manager: Processing edge {} ...".format(edge["edge_id"]))
         
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -71,7 +71,8 @@ class map_manager_2(object):
             self.tmap2["transformation"] = self.transformation
             self.tmap2["meta"] = {}
             self.tmap2["meta"]["last_updated"] = self.get_time()
-            self.tmap2["nodes"] = []
+            self.tmap2["nodes"] = []            
+            rospy.set_param('topological_map_name', self.name)
 
         self.map_pub = rospy.Publisher('/topological_map_2', std_msgs.msg.String, latch=True, queue_size=1) 
         self.map_pub.publish(std_msgs.msg.String(json.dumps(self.tmap2)))
@@ -151,6 +152,8 @@ class map_manager_2(object):
         self.transformation = self.tmap2["transformation"]
         
         self.map_check()
+        
+        rospy.set_param('topological_map_name', self.name)
         
         rospy.loginfo("Caching the map ...")
         self.write_topological_map(os.path.join(self.cache_dir, os.path.basename(self.filename)))

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -418,6 +418,8 @@ class map_manager_2(object):
             
         node["node"]["restrictions_planning"] = restrictions_planning
         node["node"]["restrictions_runtime"] = restrictions_runtime
+        
+        node["node"]["parant_frame"] = self.transformation["parent"]
             
         self.tmap2["nodes"].append(node)
         
@@ -496,7 +498,10 @@ class map_manager_2(object):
             
         if goal == "default":
             edge["goal"] = {}
-            edge["goal"]["target_pose"] = "$node.pose"
+            edge["goal"]["target_pose"] = {}
+            edge["goal"]["target_pose"]["pose"] = "$node.pose"
+            edge["goal"]["target_pose"]["header"] = {}
+            edge["goal"]["target_pose"]["header"]["frame_id"] = "$node.parent_frame"
         else:
             edge["goal"] = goal
             

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -113,6 +113,7 @@ class map_manager_2(object):
         self.rm_param_from_edge_config_srv=rospy.Service('/topological_map_manager2/rm_param_from_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.rm_param_from_edge_config_cb)
         self.update_node_restrictions_srv=rospy.Service('/topological_map_manager2/update_node_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_node_restrictions_cb)
         self.update_edge_restrictions_srv=rospy.Service('/topological_map_manager2/update_edge_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_edge_restrictions_cb)
+        self.update_action_type_srv=rospy.Service('/topological_map_manager2/update_action_type', topological_navigation_msgs.srv.UpdateActionType, self.update_action_type_cb)
 
         
     def get_time(self):
@@ -977,6 +978,29 @@ class map_manager_2(object):
         else:
             rospy.logerr("Error updating the restrictions of edge {}. {} instances of node with name {} found".format(edge_id, num_available, node_name))
             return False, ""
+        
+        
+    def update_action_type_cb(self, req):
+        """
+        Updates an edge's action type (definition) for all edges in the tmap
+        """
+        return self.update_action_type(req.action_name, req.action_type)
+    
+    
+    def update_action_type(self, action_name, action_type):
+        
+        success = False
+        for node in self.tmap2["nodes"]:
+            for edge in node["node"]["edges"]:
+                if edge["action"] == action_name:
+                    edge["action_type"] = action_type
+                    success = True
+        
+        if success:            
+            self.update()
+            self.write_topological_map(self.filename)
+    
+        return success
         
         
     def get_instances_of_node(self, node_name):

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -420,7 +420,7 @@ class map_manager_2(object):
         node["node"]["restrictions_planning"] = restrictions_planning
         node["node"]["restrictions_runtime"] = restrictions_runtime
         
-        node["node"]["parant_frame"] = self.transformation["parent"]
+        node["node"]["parent_frame"] = self.transformation["parent"]
             
         self.tmap2["nodes"].append(node)
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -477,7 +477,7 @@ class map_manager_2(object):
         
         
     def add_edge_to_node(self, origin, destination, action="move_base", edge_id="default", config=[], 
-                         recovery_behaviours_config="", action_type="default", goal="default", fail_policy="fail", 
+                         recovery_behaviours_config="", action_type="move_base_msgs/MoveBaseGoal", goal="default", fail_policy="fail", 
                          restrictions_planning="True", restrictions_runtime="True"):
         
         edge = {}
@@ -1075,14 +1075,7 @@ class map_manager_2(object):
                 msg.map = self.metric_map
                 msg.pointset = point_set
                 
-                msg.pose.position.x = node["node"]["pose"]["position"]["x"]
-                msg.pose.position.y = node["node"]["pose"]["position"]["y"]
-                msg.pose.position.z = node["node"]["pose"]["position"]["z"]
-                
-                msg.pose.orientation.x = node["node"]["pose"]["orientation"]["x"]
-                msg.pose.orientation.y = node["node"]["pose"]["orientation"]["y"]
-                msg.pose.orientation.z = node["node"]["pose"]["orientation"]["z"]
-                msg.pose.orientation.w = node["node"]["pose"]["orientation"]["w"]
+                msg.pose = message_converter.convert_dictionary_to_ros_message("geometry_msgs/Pose", node["node"]["pose"])
                 
                 msg.yaw_goal_tolerance = node["node"]["properties"]["yaw_goal_tolerance"]
                 msg.xy_goal_tolerance = node["node"]["properties"]["xy_goal_tolerance"]

--- a/topological_navigation/src/topological_navigation/route_search2.py
+++ b/topological_navigation/src/topological_navigation/route_search2.py
@@ -45,7 +45,7 @@ class TopologicalRouteSearch2(object):
         #print 'searching route from %s to %s' %(orig.name, goal.name)
 
         #self.get_distance_to_node(goal, orig)
-        nte = NodeToExpand(orig["name"], 'none', 0.0, get_distance_to_node_tmap2(goal, orig))  #Node to Expand
+        nte = NodeToExpand(orig["node"]["name"], 'none', 0.0, get_distance_to_node_tmap2(goal, orig))  #Node to Expand
         expanded.append(nte)
         #to_expand.append(nte)
 
@@ -61,7 +61,7 @@ class TopologicalRouteSearch2(object):
                 not_goal=False
                 route_found=True
                 cdist = get_distance_to_node_tmap2(cen, goal)
-                cnte = NodeToExpand(goal["name"], nte.name, nte.current_distance+cdist, 0.0)  #Node to Expand
+                cnte = NodeToExpand(goal["node"]["name"], nte.name, nte.current_distance+cdist, 0.0)  #Node to Expand
                 expanded.append(cnte)
                 #print "goal found"
             else :
@@ -90,7 +90,7 @@ class TopologicalRouteSearch2(object):
                         nnn = get_node_from_tmap2(self.top_map, i)
                         tdist = get_distance_to_node_tmap2(goal, nnn)
                         cdist = get_distance_to_node_tmap2(cen, nnn)
-                        cnte = NodeToExpand(nnn["name"], nte.name, nte.current_distance+cdist, tdist)  #Node to Expand
+                        cnte = NodeToExpand(nnn["node"]["name"], nte.name, nte.current_distance+cdist, tdist)  #Node to Expand
                         to_expand.append(cnte)
                         to_expand = sorted(to_expand, key=lambda node: node.cost)
                     else:

--- a/topological_navigation/src/topological_navigation/tmap_utils.py
+++ b/topological_navigation/src/topological_navigation/tmap_utils.py
@@ -28,7 +28,7 @@ def get_node(top_map, node_name):
 def get_node_from_tmap2(top_map, node_name):
     for i in top_map["nodes"]:
         if i["node"]["name"] == node_name:
-            return i["node"]
+            return i
     return None
 
 
@@ -95,8 +95,8 @@ def get_distance_to_node(nodea, nodeb):
 
 def get_distance_to_node_tmap2(nodea, nodeb):
     dist = math.hypot(
-        (nodeb["pose"]["position"]["x"] - nodea["pose"]["position"]["x"]),
-        (nodeb["pose"]["position"]["y"] - nodea["pose"]["position"]["y"]),
+        (nodeb["node"]["pose"]["position"]["x"] - nodea["node"]["pose"]["position"]["x"]),
+        (nodeb["node"]["pose"]["position"]["y"] - nodea["node"]["pose"]["position"]["y"]),
     )
     return dist
 
@@ -124,7 +124,7 @@ def get_conected_nodes(node):
 
 def get_conected_nodes_tmap2(node):
     childs = []
-    for i in node["edges"]:
+    for i in node["node"]["edges"]:
         childs.append(i["node"])
     return childs
 
@@ -155,7 +155,7 @@ def get_edges_between(top_map, nodea, nodeb):
 def get_edges_between_tmap2(top_map, nodea, nodeb):
     ab = []
     noda = get_node_from_tmap2(top_map, nodea)
-    for j in noda["edges"]:
+    for j in noda["node"]["edges"]:
         if j["node"] == nodeb:
             ab.append(j)
     return ab
@@ -185,7 +185,7 @@ def get_edge_from_id(top_map, node_name, edge_id):
 
 def get_edge_from_id_tmap2(top_map, node_name, edge_id):
     node = get_node_from_tmap2(top_map, node_name)
-    for i in node["edges"]:
+    for i in node["node"]["edges"]:
         if i["edge_id"] == edge_id:
             return i
     return None

--- a/topological_navigation_msgs/CMakeLists.txt
+++ b/topological_navigation_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ add_service_files(
   WriteTopologicalMap.srv
   UpdateEdgeConfig.srv
   UpdateRestrictions.srv
+  UpdateActionType.srv
 )
 
 

--- a/topological_navigation_msgs/srv/UpdateActionType.srv
+++ b/topological_navigation_msgs/srv/UpdateActionType.srv
@@ -1,0 +1,4 @@
+string action_name    # the action for which you are setting the type
+string action_type    # e.g. move_base_msgs/MoveBaseGoal
+---
+bool success


### PR DESCRIPTION
Resolves https://github.com/LCAS/topological_navigation/issues/36

The args in the edge's goal field map directly to the args of the ROS msg specified in the edge's action type field.
Properties of the edge's destination node can be passed to the goal.
Therefore actions that can be executed by toponav are no longer limited to those that use move base type goals.
An 'EdgeActionManager' class has been made to handle most of this (generation of the goal, action client and the execution of the action).
Monitored navigation removed.

New manager 2 srv for updating the action type of each edge in the tmap according to the action name.

get_node_from_tmap2 utility modified so it returns all of the node inc its meta info and consequent changes to other files.

Functions of edge reconf manager called only when there are params to reconfigure.

Lots of tidying :)