### PR TITLE
Switch map srv looks for maps in current working directory and also converts from tmap1 to tmap2 and vice-versa.

### DIFF
--- a/topological_navigation/config/sample_edge_reconfig_groups.yaml
+++ b/topological_navigation/config/sample_edge_reconfig_groups.yaml
@@ -1,0 +1,141 @@
+edge_nav_reconfig_groups:
+  irn:
+    edges: []
+    parameters:
+      - &id001
+        name: forward_point_distance
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.48297542551971
+      - &id002
+        name: vth_samples
+        ns: move_base/DWAPlannerROS
+        type: int
+        value: 67.0
+      - &id003
+        name: prune_plan
+        ns: move_base/DWAPlannerROS
+        type: bool
+        value: true
+      - &id004
+        name: goal_distance_bias
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 37.0
+      - &id005
+        name: occdist_scale
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.17095456476021975
+      - &id006
+        name: vx_samples
+        ns: move_base/DWAPlannerROS
+        type: int
+        value: 35.0
+      - &id007
+        name: path_distance_bias
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 28.786107042177363
+      - &id008
+        name: sim_time
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 2.56592652856906
+      - &id009
+        name: max_scaling_factor
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.572649261744206
+      - &id010
+        name: scaling_speed
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.013910991085600694
+      - &id011
+        name: sim_granularity
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.04403610426260697
+      - &id012
+        name: stop_time_buffer
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.18229162576485147
+      - &id013
+        name: oscillation_reset_dist
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.015779064792816565
+  orn:
+    edges: []
+    parameters:
+      - *id001
+      - *id002
+      - *id003
+      - *id004
+      - *id005
+      - *id006
+      - *id007
+      - *id008
+      - *id009
+      - *id010
+      - *id011
+      - *id012
+      - *id013
+  utn:
+    edges: []
+    parameters:
+      - name: forward_point_distance
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.1402690117118645
+      - name: vth_samples
+        ns: move_base/DWAPlannerROS
+        type: int
+        value: 73.0
+      - name: prune_plan
+        ns: move_base/DWAPlannerROS
+        type: bool
+        value: false
+      - name: goal_distance_bias
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 55.0
+      - name: occdist_scale
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.5922531975286119
+      - name: vx_samples
+        ns: move_base/DWAPlannerROS
+        type: int
+        value: 50.0
+      - name: path_distance_bias
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 7.0
+      - name: sim_time
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 2.801314735789211
+      - name: max_scaling_factor
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.8779488542935023
+      - name: scaling_speed
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.31177421746048395
+      - name: sim_granularity
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.02537100021859829
+      - name: stop_time_buffer
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 1.0
+      - name: oscillation_reset_dist
+        ns: move_base/DWAPlannerROS
+        type: double
+        value: 0.054441156382406555
+

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -105,7 +105,6 @@ class TopologicalNavLoc(object):
         self.closest_edge_ids = []
         self.closest_edge_dists = []
         self.node_poses = {}
-        self.err_msg_sent = False
         
         # TODO: remove Temporary arg until tags functionality is MongoDB independent
         self.with_tags = wtags
@@ -323,6 +322,7 @@ class TopologicalNavLoc(object):
         self.names_by_topic=[]
         self.nodes_by_topic=[]
         self.nogos=[]
+        self.err_msg_sent = False
 
         self.tmap = json.loads(msg.data) 
         self.rec_map=True

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -105,6 +105,7 @@ class TopologicalNavLoc(object):
         self.closest_edge_ids = []
         self.closest_edge_dists = []
         self.node_poses = {}
+        self.err_msg_sent = False
         
         # TODO: remove Temporary arg until tags functionality is MongoDB independent
         self.with_tags = wtags
@@ -139,7 +140,6 @@ class TopologicalNavLoc(object):
         self.base_frame = rospy.get_param("~base_frame", "base_link")
         
         rospy.loginfo("Listening to the tf transform between {} and {}".format(self.tmap_frame, self.base_frame))
-        self.err_msg_sent = False
         self.listener = tf.TransformListener()
         self.rate = rospy.Rate(10.0)
         self.PoseCallback()
@@ -169,8 +169,8 @@ class TopologicalNavLoc(object):
         """
         pnt = (pose.position.x, pose.position.y, 0)
         distances = []
-        
         bad_edges = []
+        
         for node in self.tmap["nodes"]:
             start = (node["node"]["pose"]["position"]["x"], node["node"]["pose"]["position"]["y"], 0)
             
@@ -189,12 +189,11 @@ class TopologicalNavLoc(object):
                 a["dist"] = dist
                 distances.append(a)
                 
-        if bad_edges and not self.err_msg_sent:
+        if not self.err_msg_sent and bad_edges:
             for item in bad_edges:
                 rospy.logerr("Cannot get distance to edge {}: {}".format(item[0], item[1]))
             self.err_msg_sent = True
             
-                 
         distances = sorted(distances, key=lambda k: k["dist"])
         return distances
 

--- a/topological_navigation/scripts/localisation.py
+++ b/topological_navigation/scripts/localisation.py
@@ -189,7 +189,7 @@ class TopologicalNavLoc(object):
                 a["dist"] = dist
                 distances.append(a)
                 
-        if not self.err_msg_sent and bad_edges:
+        if bad_edges and not self.err_msg_sent:
             for item in bad_edges:
                 rospy.logerr("Cannot get distance to edge {}: {}".format(item[0], item[1]))
             self.err_msg_sent = True

--- a/topological_navigation/scripts/map_manager2.py
+++ b/topological_navigation/scripts/map_manager2.py
@@ -37,6 +37,7 @@ if __name__ == '__main__' :
             print "Loading Map (%s)" %_map
 
     rospy.init_node("topological_map_manager")
-    ps = map_manager_2(filename=_map, load=load)
+    ps = map_manager_2()
+    ps.initialise(filename=_map, load=load)
     rospy.spin()
 #########################################################################################################

--- a/topological_navigation/scripts/map_manager2.py
+++ b/topological_navigation/scripts/map_manager2.py
@@ -38,6 +38,6 @@ if __name__ == '__main__' :
 
     rospy.init_node("topological_map_manager")
     ps = map_manager_2()
-    ps.initialise(filename=_map, load=load)
+    ps.init_map(filename=_map, load=load)
     rospy.spin()
 #########################################################################################################

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -335,9 +335,7 @@ class TopologicalNavServer(object):
         to reach it.
         """
         result = False
-        route_found = False
-
-        while not result and not self.cancelled:
+        if not self.cancelled:
             o_node = get_node_from_tmap2(self.lnodes, self.closest_node)
             g_node = get_node_from_tmap2(self.lnodes, target)
 
@@ -349,7 +347,6 @@ class TopologicalNavServer(object):
                 route = self.enforce_navigable_route(route, target)
 
                 if route.source:
-                    route_found = True
                     rospy.loginfo("Navigating Case 1")
                     self.publish_route(route, target)
                     result, inc = self.followRoute(route, target, 0)
@@ -357,6 +354,7 @@ class TopologicalNavServer(object):
                 else:
                     rospy.logerr("There is no route to this node check your edges ...")
                     rospy.loginfo("Navigating Case 1b")
+                    self.cancelled = True
                     result = False
                     inc = 1
                     rospy.loginfo("Navigating Case 1b -> res: %d", inc)
@@ -368,9 +366,6 @@ class TopologicalNavServer(object):
                 inc = 1
                 rospy.loginfo("Navigating Case 3a -> res: %d", inc)
         
-        if not route_found:
-            self.cancelled = True
-
         if (not self.cancelled) and (not self.preempted):
             self._result.success = result
             self._feedback.route = target

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -129,6 +129,7 @@ class TopologicalNavServer(object):
         rospy.loginfo(" ...done")
 
         self.edge_reconfigure = rospy.get_param("~reconfigure_edges", False)
+        self.srv_edge_reconfigure = rospy.get_param("~reconfigure_edges_srv", True)
         if self.edge_reconfigure:
             self.edgeReconfigureManager = EdgeReconfigureManager()
 
@@ -552,14 +553,17 @@ class TopologicalNavServer(object):
             dt_text = self.stat.get_start_time_str()
 
             if self.edge_reconfigure:
-                self.edgeReconfigureManager.register_edge(cedg)
-                if self.edgeReconfigureManager.active:
-                    self.edgeReconfigureManager.initialise()
-                    self.edgeReconfigureManager.reconfigure()
+                if not self.srv_edge_reconfigure:
+                    self.edgeReconfigureManager.register_edge(cedg)
+                    if self.edgeReconfigureManager.active:
+                        self.edgeReconfigureManager.initialise()
+                        self.edgeReconfigureManager.reconfigure()
+                else:
+                    self.edgeReconfigureManager.srv_reconfigure(cedg["edge_id"])
 
             nav_ok, inc = self.execute_action(cedg, cnode)
 
-            if self.edge_reconfigure and self.edgeReconfigureManager.active:
+            if self.edge_reconfigure and not self.srv_edge_reconfigure and self.edgeReconfigureManager.active:
                 self.edgeReconfigureManager._reset()
                 rospy.sleep(rospy.Duration.from_sec(0.3))
 

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -13,9 +13,9 @@ from rospy_message_converter import message_converter
 from actionlib_msgs.msg import GoalStatus
 
 
-def _import(location, object_name):
-    mod = __import__(location, fromlist=[object_name]) 
-    return getattr(mod, object_name) 
+def _import(location, name):
+    mod = __import__(location, fromlist=[name]) 
+    return getattr(mod, name) 
 
 
 class dict_tools(object):
@@ -69,7 +69,7 @@ class EdgeActionManager(object):
         rospy.loginfo("Edge Action Manager: Processing edge {}".format(self.edge["edge_id"]))
         
         self.action_name = self.edge["action"]
-        if self.action_name != self.current_action and self.current_action is not None:
+        if self.action_name != self.current_action:
             self.preempt()
 
         action_type = self.edge["action_type"]        

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -67,7 +67,7 @@ class EdgeActionManager(object):
         self.edge = eval(json.dumps(edge)) # remove unicode prefix notation u
         self.destination_node = eval(json.dumps(destination_node))
         
-        rospy.loginfo("Edge Action Manager: Processing edge {} ...".format(self.edge["edge_id"]))
+        rospy.loginfo("Edge Action Manager: Processing edge {}".format(self.edge["edge_id"]))
         
         self.action_name = self.edge["action"]
         if self.action_name != self.current_action and self.current_action is not None:
@@ -81,7 +81,7 @@ class EdgeActionManager(object):
         rospy.loginfo("Edge Action Manager: Importing {} from {}.msg".format(action_spec, package))
         action = _import(package + ".msg", action_spec)
         
-        rospy.loginfo("Edge Action Manager: Creating a {} client".format(self.action_name))
+        rospy.loginfo("Edge Action Manager: Creating a {} client".format(self.action_name.upper()))
         self.client = actionlib.SimpleActionClient(self.action_name, action)        
         self.client.wait_for_server()
         

--- a/topological_navigation/src/topological_navigation/edge_action_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_action_manager.py
@@ -10,7 +10,6 @@ import operator, collections, json
 
 from functools import reduce  # forward compatibility for Python 3
 from rospy_message_converter import message_converter
-
 from actionlib_msgs.msg import GoalStatus
 
 

--- a/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
+++ b/topological_navigation/src/topological_navigation/edge_reconfigure_manager.py
@@ -39,7 +39,7 @@ class EdgeReconfigureManager(object):
         self.namespaces = list(set(namespaces))
         if self.namespaces:
             self.active = True
-            rospy.loginfo("Edge Reconfigure Manager: Processing edge {} ...".format(edge["edge_id"]))
+            rospy.loginfo("Edge Reconfigure Manager: Processing edge {}".format(edge["edge_id"]))
         
         
     def initialise(self):

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -39,6 +39,7 @@ class map_manager(object):
                 rospy.set_param('topological_map_path', os.path.split(name)[0])
                 
             self.names = self.create_list_of_nodes()
+            self.manager2 = map_manager_2()
             self.tmap_to_tmap2() # convert map to new format
         else:
             self.nodes = strands_navigation_msgs.msg.TopologicalMap()
@@ -977,7 +978,7 @@ class map_manager(object):
         if self.load_from_file:
             filename = os.path.splitext(self.name)[0] + ".yaml"
             
-        manager2 = map_manager_2(name=self.nodes.name, metric_map=self.nodes.map, pointset=self.nodes.pointset, filename=filename, load=False)
+        self.manager2.initialise(name=self.nodes.name, metric_map=self.nodes.map, pointset=self.nodes.pointset, filename=filename, load=False)
         
         for node in self.nodes.nodes:
             
@@ -992,10 +993,10 @@ class map_manager(object):
             req.node_name = node.name
             tags = self.get_node_tags_cb(req)[1]
             
-            manager2.add_node(node.name, pose, node.localise_by_topic, verts, properties, tags)
+            self.manager2.add_node(node.name, pose, node.localise_by_topic, verts, properties, tags)
             
             for edge in node.edges:
-                manager2.add_edge_to_node(node.name, edge.node, edge.action, edge.edge_id, [], edge.recovery_behaviours_config)
+                self.manager2.add_edge_to_node(node.name, edge.node, edge.action, edge.edge_id, [], edge.recovery_behaviours_config)
                 
-        manager2.update()
+        self.manager2.update()
 ###################################################################################################################

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -37,6 +37,7 @@ class map_manager(object):
             else:
                 self.nodes, self.tmap = self.load_map_from_file(name)
                 rospy.set_param('topological_map_path', os.path.split(name)[0])
+                rospy.set_param('topological_map_filename', os.path.split(name)[1])
                 
             self.names = self.create_list_of_nodes()
             self.manager2 = map_manager_2()
@@ -419,6 +420,7 @@ class map_manager(object):
             self.name = req.pointset
             print "Returning Map {}".format(req.pointset)
         else:
+            rospy.set_param('topological_map_filename', req.pointset)
             path = rospy.get_param('topological_map_path')
             f = path + "/" + req.pointset
             self.nodes, self.tmap = self.load_map_from_file(f)

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -21,6 +21,7 @@ def node_dist(node1,node2):
     dist = math.sqrt((node1.pose.position.x - node2.pose.position.x)**2 + (node1.pose.position.y - node2.pose.position.y)**2 )
     return dist
 
+
 class map_manager(object):
 
     def __init__(self, name, load=True, load_from_file=False) :
@@ -33,15 +34,13 @@ class map_manager(object):
         if load:
             if not load_from_file:
                 self.nodes = self.loadMap(name)
+                rospy.set_param('topological_map_name', self.nodes.pointset)
             else:
                 self.nodes, self.tmap = self.load_map_from_file(name)
+                rospy.set_param('topological_map_name', name)
             self.names = self.create_list_of_nodes()
             self.tmap_to_tmap2() # convert map to new format
 
-            if not load_from_file:
-                rospy.set_param('topological_map_name', self.nodes.pointset)
-            else:
-                rospy.set_param('topological_map_name', name)
         else:
             self.nodes = strands_navigation_msgs.msg.TopologicalMap()
             self.nodes.name = name
@@ -98,6 +97,7 @@ class map_manager(object):
         self.last_updated = rospy.Time.now()
         self.map_pub.publish(self.nodes)
         self.names = self.create_list_of_nodes()
+        rospy.set_param('topological_map_name', self.nodes.pointset)
 
 
     def get_tags_cb(self, req):
@@ -427,6 +427,7 @@ class map_manager(object):
         #nodes.nodes.sort(key=lambda node: node.name)
         self.names = self.create_list_of_nodes()
         self.map_pub.publish(self.nodes)
+        self.tmap_to_tmap2() # convert map to new format
                     
         rospy.set_param('topological_map_name', req.pointset)
         return self.nodes
@@ -995,12 +996,7 @@ class map_manager(object):
             manager2.add_node(node.name, pose, node.localise_by_topic, verts, properties, tags)
             
             for edge in node.edges:
-                
-                config = []
-                #config.append({"namespace":"move_base/DWAPlannerROS", "name":"inflation_radius", "value":edge.inflation_radius})
-                #config.append({"namespace":"move_base/DWAPlannerROS", "name":"top_vel", "value":edge.top_vel})
-                
-                manager2.add_edge_to_node(node.name, edge.node, edge.action, edge.edge_id, config, edge.recovery_behaviours_config)
+                manager2.add_edge_to_node(node.name, edge.node, edge.action, edge.edge_id, [], edge.recovery_behaviours_config)
                 
         manager2.update()
 ###################################################################################################################

--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -978,7 +978,7 @@ class map_manager(object):
         if self.load_from_file:
             filename = os.path.splitext(self.name)[0] + ".yaml"
             
-        self.manager2.initialise(name=self.nodes.name, metric_map=self.nodes.map, pointset=self.nodes.pointset, filename=filename, load=False)
+        self.manager2.init_map(name=self.nodes.name, metric_map=self.nodes.map, pointset=self.nodes.pointset, filename=filename, load=False)
         
         for node in self.nodes.nodes:
             

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -1064,7 +1064,7 @@ class map_manager_2(object):
         for node in self.tmap2["nodes"]:
             for edge in node["node"]["edges"]:
                 if node["node"]["name"] == edge["node"]:
-                    rospy.logwarn("edge with id {} has a destination {} equal to its origin".format(edge["edge_id"], edge["node"]))
+                    rospy.logwarn("edge with id '{}' has a destination '{}' equal to its origin".format(edge["edge_id"], edge["node"]))
                     self.map_ok = False
                     
                 

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -22,8 +22,7 @@ from rospy_message_converter import message_converter
 
 
 def pose_dist(pose1, pose2):
-    dist = math.sqrt((pose1["position"]["x"] - pose2["position"]["x"])**2 + (pose1["position"]["y"] - pose2["position"]["y"])**2)
-    return dist
+    return math.sqrt((pose1["position"]["x"] - pose2["position"]["x"])**2 + (pose1["position"]["y"] - pose2["position"]["y"])**2)
 
 
 class map_manager_2(object):
@@ -56,7 +55,6 @@ class map_manager_2(object):
         self.modify_tag_srv=rospy.Service('/topological_map_manager2/modify_node_tags', strands_navigation_msgs.srv.ModifyTag, self.modify_tag_cb)
         self.add_tag_srv=rospy.Service('/topological_map_manager2/add_tag_to_node', strands_navigation_msgs.srv.AddTag, self.add_tag_cb)
         self.rm_tag_srv=rospy.Service('/topological_map_manager2/rm_tag_from_node', strands_navigation_msgs.srv.AddTag, self.rm_tag_cb)        
-        self.update_edge_srv=rospy.Service('/topological_map_manager2/update_edge', strands_navigation_msgs.srv.UpdateEdge, self.update_edge_cb)
         self.add_param_to_edge_config_srv=rospy.Service('/topological_map_manager2/add_param_to_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.add_param_to_edge_config_cb)
         self.rm_param_from_edge_config_srv=rospy.Service('/topological_map_manager2/rm_param_from_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.rm_param_from_edge_config_cb)
         self.update_node_restrictions_srv=rospy.Service('/topological_map_manager2/update_node_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_node_restrictions_cb)
@@ -65,7 +63,7 @@ class map_manager_2(object):
         self.update_action_srv=rospy.Service('/topological_map_manager2/update_action', topological_navigation_msgs.srv.UpdateAction, self.update_action_cb)
     
     
-    def initialise(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
+    def init_map(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
         
         self.name = name
         self.metric_map = metric_map
@@ -801,34 +799,6 @@ class map_manager_2(object):
             self.write_topological_map(self.filename)
 
         return succeded, meta_out
-    
-    
-    def update_edge_cb(self, req):
-        """
-        Update an edge's action
-        """
-        return self.update_edge(req.edge_id, req.action)
-      
-
-    def update_edge(self, edge_id, action):
-        
-        node_name = edge_id.split('_')[0]
-        num_available, index = self.get_instances_of_node(node_name)
-        
-        if num_available == 1:
-            the_node = copy.deepcopy(self.tmap2["nodes"][index])
-            for edge in the_node["node"]["edges"]:
-                if edge["edge_id"] == edge_id:
-                    edge["action"] = action or edge["action"]
-                    
-            self.tmap2["nodes"][index] = the_node
-            self.update()
-            self.write_topological_map(self.filename)
-        
-            return True, ""
-        else:
-            rospy.logerr("Cannot update edge {}. {} instances of node with name {} found".format(edge_id, num_available, node_name))
-            return False, "no edge found or multiple edges found"
         
         
     def add_param_to_edge_config_cb(self, req):

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -102,8 +102,7 @@ class map_manager_2(object):
             self.tmap2["meta"] = {}
             self.tmap2["meta"]["last_updated"] = self.get_time()
             self.tmap2["nodes"] = []            
-            rospy.set_param('topological_map2_name', self.pointset)
-            rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
+            rospy.set_param('topological_map_name', self.filename)
 
         self.map_pub = rospy.Publisher('/topological_map_2', std_msgs.msg.String, latch=True, queue_size=1) 
         self.map_pub.publish(std_msgs.msg.String(json.dumps(self.tmap2)))
@@ -113,8 +112,8 @@ class map_manager_2(object):
         self.broadcast_transform()
         
         self.convert_to_legacy = rospy.get_param("~convert_to_legacy", True)
+        self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
         if self.loaded and self.convert_to_legacy:
-            self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
             self.tmap2_to_tmap()
             self.points_pub.publish(self.points)
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -31,6 +31,10 @@ class map_manager_2(object):
     
     def __init__(self):
         
+        self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
+        if not os.path.exists(self.cache_dir):
+            os.mkdir(self.cache_dir)
+        
         # Services that retrieve information from the map
         self.get_map_srv=rospy.Service('/topological_map_manager2/get_topological_map', Trigger, self.get_topological_map_cb)
         self.switch_map_srv=rospy.Service('/topological_map_manager2/switch_topological_map', topological_navigation_msgs.srv.WriteTopologicalMap, self.switch_topological_map_cb)
@@ -62,10 +66,6 @@ class map_manager_2(object):
     
     
     def initialise(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
-        
-        self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
-        if not os.path.exists(self.cache_dir):
-            os.mkdir(self.cache_dir)
         
         self.name = name
         self.metric_map = metric_map
@@ -151,13 +151,14 @@ class map_manager_2(object):
             return
         
         self.loaded = True
+        self.map_check()
             
         self.name = self.tmap2["name"]
         self.metric_map = self.tmap2["metric_map"]
         self.pointset = self.tmap2["pointset"]
         self.transformation = self.tmap2["transformation"]
         
-        self.map_check()
+        self.names = self.create_list_of_nodes()
         
         rospy.set_param('topological_map2_name', self.pointset)
         rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
@@ -211,13 +212,10 @@ class map_manager_2(object):
         
     def create_list_of_nodes(self):
         
-        names = []
-        if "nodes" in self.tmap2:
-            names = [node["node"]["name"] for node in self.tmap2["nodes"]]
-            names.sort()
-            
+        names = [node["node"]["name"] for node in self.tmap2["nodes"]]
+        names.sort()
         return names
-        
+            
         
     def get_topological_map_cb(self, req):
         """

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -103,6 +103,7 @@ class map_manager_2(object):
             self.tmap2["meta"]["last_updated"] = self.get_time()
             self.tmap2["nodes"] = []            
             rospy.set_param('topological_map2_name', self.pointset)
+            rospy.set_param('topological_map2_filename', os.path.split(self.filename)[1])
             rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
 
         self.map_pub = rospy.Publisher('/topological_map_2', std_msgs.msg.String, latch=True, queue_size=1) 
@@ -159,6 +160,7 @@ class map_manager_2(object):
         self.names = self.create_list_of_nodes()
         
         rospy.set_param('topological_map2_name', self.pointset)
+        rospy.set_param('topological_map2_filename', os.path.split(self.filename)[1])
         rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
         
         rospy.loginfo("Caching the map ...")
@@ -230,6 +232,7 @@ class map_manager_2(object):
         """
         Changes the topological map
         """
+        rospy.set_param('topological_map2_filename', req.filename)
         path = rospy.get_param('topological_map2_path')
         self.filename = path + "/" + req.filename
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -104,7 +104,8 @@ class map_manager_2(object):
             self.tmap2["meta"] = {}
             self.tmap2["meta"]["last_updated"] = self.get_time()
             self.tmap2["nodes"] = []            
-            rospy.set_param('topological_map_name', self.filename)
+            rospy.set_param('topological_map2_name', self.pointset)
+            rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
 
         self.map_pub = rospy.Publisher('/topological_map_2', std_msgs.msg.String, latch=True, queue_size=1) 
         self.map_pub.publish(std_msgs.msg.String(json.dumps(self.tmap2)))
@@ -114,8 +115,8 @@ class map_manager_2(object):
         self.broadcast_transform()
         
         self.convert_to_legacy = rospy.get_param("~convert_to_legacy", True)
-        self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
         if self.loaded and self.convert_to_legacy:
+            self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
             self.tmap2_to_tmap()
             self.points_pub.publish(self.points)
         

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -158,7 +158,8 @@ class map_manager_2(object):
         
         self.map_check()
         
-        rospy.set_param('topological_map_name', self.filename)
+        rospy.set_param('topological_map2_name', self.pointset)
+        rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
         
         rospy.loginfo("Caching the map ...")
         self.write_topological_map(os.path.join(self.cache_dir, os.path.basename(self.filename)))
@@ -232,16 +233,14 @@ class map_manager_2(object):
         """
         Changes the topological map
         """
-        self.filename = req.filename
-        self.load_map(req.filename)        
+        path = rospy.get_param('topological_map2_path')
+        self.filename = path + "/" + req.filename
+        
+        self.load_map(self.filename)        
         self.update(False)
         self.broadcast_transform()
-        
-        success = True
-        if not self.tmap2:
-            success = False
-            
-        return success, json.dumps(self.tmap2)
+
+        return True, json.dumps(self.tmap2)
     
     
     def get_tagged_cb(self, req):

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -29,7 +29,39 @@ def pose_dist(pose1, pose2):
 class map_manager_2(object):
     
     
-    def __init__(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
+    def __init__(self):
+        
+        # Services that retrieve information from the map
+        self.get_map_srv=rospy.Service('/topological_map_manager2/get_topological_map', Trigger, self.get_topological_map_cb)
+        self.switch_map_srv=rospy.Service('/topological_map_manager2/switch_topological_map', topological_navigation_msgs.srv.WriteTopologicalMap, self.switch_topological_map_cb)
+        self.get_tagged_srv=rospy.Service('/topological_map_manager2/get_tagged_nodes', strands_navigation_msgs.srv.GetTaggedNodes, self.get_tagged_cb)       
+        self.get_tag_srv=rospy.Service('/topological_map_manager2/get_tags', strands_navigation_msgs.srv.GetTags, self.get_tags_cb)
+        self.get_node_tag_srv=rospy.Service('/topological_map_manager2/get_node_tags', strands_navigation_msgs.srv.GetNodeTags, self.get_node_tags_cb)
+        self.get_node_edges_srv=rospy.Service('/topological_map_manager2/get_edges_between_nodes', strands_navigation_msgs.srv.GetEdgesBetweenNodes, self.get_edges_between_cb)
+
+        # Services that modify the map
+        self.write_map_srv=rospy.Service('/topological_map_manager2/write_topological_map', topological_navigation_msgs.srv.WriteTopologicalMap, self.write_topological_map_cb)
+        self.add_node_srv=rospy.Service('/topological_map_manager2/add_topological_node', strands_navigation_msgs.srv.AddNode, self.add_topological_node_cb)
+        self.remove_node_srv=rospy.Service('/topological_map_manager2/remove_topological_node', strands_navigation_msgs.srv.RmvNode, self.remove_node_cb)
+        self.add_edges_srv=rospy.Service('/topological_map_manager2/add_edges_between_nodes', strands_navigation_msgs.srv.AddEdge, self.add_edge_cb)
+        self.remove_edge_srv=rospy.Service('/topological_map_manager2/remove_edge', strands_navigation_msgs.srv.AddEdge, self.remove_edge_cb)
+        self.add_content_to_node_srv=rospy.Service('/topological_map_manager2/add_content_to_node', strands_navigation_msgs.srv.AddContent, self.add_content_cb)
+        self.update_node_name_srv = rospy.Service("/topological_map_manager2/update_node_name", strands_navigation_msgs.srv.UpdateNodeName, self.update_node_name_cb)
+        self.update_node_waypoint_srv = rospy.Service("/topological_map_manager2/update_node_pose", strands_navigation_msgs.srv.AddNode, self.update_node_waypoint_cb)
+        self.update_node_tolerance_srv = rospy.Service("/topological_map_manager2/update_node_tolerance", strands_navigation_msgs.srv.UpdateNodeTolerance, self.update_node_tolerance_cb)
+        self.modify_tag_srv=rospy.Service('/topological_map_manager2/modify_node_tags', strands_navigation_msgs.srv.ModifyTag, self.modify_tag_cb)
+        self.add_tag_srv=rospy.Service('/topological_map_manager2/add_tag_to_node', strands_navigation_msgs.srv.AddTag, self.add_tag_cb)
+        self.rm_tag_srv=rospy.Service('/topological_map_manager2/rm_tag_from_node', strands_navigation_msgs.srv.AddTag, self.rm_tag_cb)        
+        self.update_edge_srv=rospy.Service('/topological_map_manager2/update_edge', strands_navigation_msgs.srv.UpdateEdge, self.update_edge_cb)
+        self.add_param_to_edge_config_srv=rospy.Service('/topological_map_manager2/add_param_to_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.add_param_to_edge_config_cb)
+        self.rm_param_from_edge_config_srv=rospy.Service('/topological_map_manager2/rm_param_from_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.rm_param_from_edge_config_cb)
+        self.update_node_restrictions_srv=rospy.Service('/topological_map_manager2/update_node_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_node_restrictions_cb)
+        self.update_edge_restrictions_srv=rospy.Service('/topological_map_manager2/update_edge_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_edge_restrictions_cb)
+        self.update_edge_action_srv=rospy.Service('/topological_map_manager2/update_edge_action', topological_navigation_msgs.srv.UpdateAction, self.update_edge_action_cb)
+        self.update_action_srv=rospy.Service('/topological_map_manager2/update_action', topological_navigation_msgs.srv.UpdateAction, self.update_action_cb)
+    
+    
+    def initialise(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
         
         self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
         if not os.path.exists(self.cache_dir):
@@ -87,35 +119,6 @@ class map_manager_2(object):
             self.tmap2_to_tmap()
             self.points_pub.publish(self.points)
         
-        # Services that retrieve information from the map
-        self.get_map_srv=rospy.Service('/topological_map_manager2/get_topological_map', Trigger, self.get_topological_map_cb)
-        self.switch_map_srv=rospy.Service('/topological_map_manager2/switch_topological_map', topological_navigation_msgs.srv.WriteTopologicalMap, self.switch_topological_map_cb)
-        self.get_tagged_srv=rospy.Service('/topological_map_manager2/get_tagged_nodes', strands_navigation_msgs.srv.GetTaggedNodes, self.get_tagged_cb)       
-        self.get_tag_srv=rospy.Service('/topological_map_manager2/get_tags', strands_navigation_msgs.srv.GetTags, self.get_tags_cb)
-        self.get_node_tag_srv=rospy.Service('/topological_map_manager2/get_node_tags', strands_navigation_msgs.srv.GetNodeTags, self.get_node_tags_cb)
-        self.get_node_edges_srv=rospy.Service('/topological_map_manager2/get_edges_between_nodes', strands_navigation_msgs.srv.GetEdgesBetweenNodes, self.get_edges_between_cb)
-
-        # Services that modify the map
-        self.write_map_srv=rospy.Service('/topological_map_manager2/write_topological_map', topological_navigation_msgs.srv.WriteTopologicalMap, self.write_topological_map_cb)
-        self.add_node_srv=rospy.Service('/topological_map_manager2/add_topological_node', strands_navigation_msgs.srv.AddNode, self.add_topological_node_cb)
-        self.remove_node_srv=rospy.Service('/topological_map_manager2/remove_topological_node', strands_navigation_msgs.srv.RmvNode, self.remove_node_cb)
-        self.add_edges_srv=rospy.Service('/topological_map_manager2/add_edges_between_nodes', strands_navigation_msgs.srv.AddEdge, self.add_edge_cb)
-        self.remove_edge_srv=rospy.Service('/topological_map_manager2/remove_edge', strands_navigation_msgs.srv.AddEdge, self.remove_edge_cb)
-        self.add_content_to_node_srv=rospy.Service('/topological_map_manager2/add_content_to_node', strands_navigation_msgs.srv.AddContent, self.add_content_cb)
-        self.update_node_name_srv = rospy.Service("/topological_map_manager2/update_node_name", strands_navigation_msgs.srv.UpdateNodeName, self.update_node_name_cb)
-        self.update_node_waypoint_srv = rospy.Service("/topological_map_manager2/update_node_pose", strands_navigation_msgs.srv.AddNode, self.update_node_waypoint_cb)
-        self.update_node_tolerance_srv = rospy.Service("/topological_map_manager2/update_node_tolerance", strands_navigation_msgs.srv.UpdateNodeTolerance, self.update_node_tolerance_cb)
-        self.modify_tag_srv=rospy.Service('/topological_map_manager2/modify_node_tags', strands_navigation_msgs.srv.ModifyTag, self.modify_tag_cb)
-        self.add_tag_srv=rospy.Service('/topological_map_manager2/add_tag_to_node', strands_navigation_msgs.srv.AddTag, self.add_tag_cb)
-        self.rm_tag_srv=rospy.Service('/topological_map_manager2/rm_tag_from_node', strands_navigation_msgs.srv.AddTag, self.rm_tag_cb)        
-        self.update_edge_srv=rospy.Service('/topological_map_manager2/update_edge', strands_navigation_msgs.srv.UpdateEdge, self.update_edge_cb)
-        self.add_param_to_edge_config_srv=rospy.Service('/topological_map_manager2/add_param_to_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.add_param_to_edge_config_cb)
-        self.rm_param_from_edge_config_srv=rospy.Service('/topological_map_manager2/rm_param_from_edge_config', topological_navigation_msgs.srv.UpdateEdgeConfig, self.rm_param_from_edge_config_cb)
-        self.update_node_restrictions_srv=rospy.Service('/topological_map_manager2/update_node_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_node_restrictions_cb)
-        self.update_edge_restrictions_srv=rospy.Service('/topological_map_manager2/update_edge_restrictions', topological_navigation_msgs.srv.UpdateRestrictions, self.update_edge_restrictions_cb)
-        self.update_edge_action_srv=rospy.Service('/topological_map_manager2/update_edge_action', topological_navigation_msgs.srv.UpdateAction, self.update_edge_action_cb)
-        self.update_action_srv=rospy.Service('/topological_map_manager2/update_action', topological_navigation_msgs.srv.UpdateAction, self.update_action_cb)
-
         
     def get_time(self):
         return datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -102,7 +102,8 @@ class map_manager_2(object):
             self.tmap2["meta"] = {}
             self.tmap2["meta"]["last_updated"] = self.get_time()
             self.tmap2["nodes"] = []            
-            rospy.set_param('topological_map_name', self.filename)
+            rospy.set_param('topological_map2_name', self.pointset)
+            rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
 
         self.map_pub = rospy.Publisher('/topological_map_2', std_msgs.msg.String, latch=True, queue_size=1) 
         self.map_pub.publish(std_msgs.msg.String(json.dumps(self.tmap2)))
@@ -112,8 +113,8 @@ class map_manager_2(object):
         self.broadcast_transform()
         
         self.convert_to_legacy = rospy.get_param("~convert_to_legacy", True)
-        self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
         if self.loaded and self.convert_to_legacy:
+            self.points_pub = rospy.Publisher('/topological_map', strands_navigation_msgs.msg.TopologicalMap, latch=True, queue_size=1)
             self.tmap2_to_tmap()
             self.points_pub.publish(self.points)
         


### PR DESCRIPTION
Map manager switch maps service converts from tmap1 to tmap2 and map manager 2 switch maps service converts from tmap2 to tmap1.
Pass the filename (without the path) to the service request.
Map manager cwd set by param `/topological_map_path` if using the old manager and `/topological_map2_path` if using the new map manager.
Get filename from params `/topological_map_filename` and `/topological_map2_filename`.
Fix for switch map srv responding with error when converting from tmap1 to tmap2.
Lots of small improvements and tidying.