### PR TITLE
Services for updating the fail policy.

### DIFF
--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -63,6 +63,7 @@ class map_manager_2(object):
         self.update_edge_srv=rospy.Service('/topological_map_manager2/update_edge', topological_navigation_msgs.srv.UpdateEdge, self.update_edge_cb)
         self.update_action_srv=rospy.Service('/topological_map_manager2/update_action', topological_navigation_msgs.srv.UpdateAction, self.update_action_cb)
         self.add_datum_srv=rospy.Service('/topological_map_manager2/add_datum', topological_navigation_msgs.srv.AddDatum, self.add_datum_cb)
+        self.update_fail_policy_srv=rospy.Service('/topological_map_manager2/update_fail_policy', topological_navigation_msgs.srv.UpdateFailPolicy, self.update_fail_policy_cb)
     
     
     def init_map(self, name="new_map", metric_map="map_2d", pointset="new_map", transformation="default", filename="", load=True):
@@ -959,10 +960,10 @@ class map_manager_2(object):
         """
         Updates an edge's args (action, action type, goal etc)
         """
-        return self.update_edge_action(req.edge_id, req.action_name, req.action_type, req.goal, req.not_fluid)
+        return self.update_edge_action(req.edge_id, req.action_name, req.action_type, req.goal, req.fail_policy, req.not_fluid)
     
     
-    def update_edge_action(self, edge_id, action_name, action_type, goal, not_fluid):
+    def update_edge_action(self, edge_id, action_name, action_type, goal, fail_policy, not_fluid):
         
         node_name, _ = get_node_names_from_edge_id_2(self.tmap2, edge_id)
         num_available, index = self.get_instances_of_node(node_name)
@@ -977,6 +978,8 @@ class map_manager_2(object):
                         edge["action_type"] = action_type
                     if goal:
                         edge["goal"] = json.loads(goal)
+                    if fail_policy:
+                        edge["fail_policy"] = fail_policy
                     if not_fluid:
                         edge["fluid_navigation"] = False
                     else:
@@ -1029,6 +1032,32 @@ class map_manager_2(object):
         try:
             self.tmap2["meta"]["datum_latitude"] = latitude
             self.tmap2["meta"]["datum_longitude"] = longitude
+            self.update()
+            self.write_topological_map(self.filename)
+            return True
+        
+        except Exception as e:
+            rospy.logerr(e)
+            return False
+        
+        
+    def update_fail_policy_cb(self, req):
+        """
+        Update he fail policy of all edges in the map
+        """  
+        return self.update_fail_policy(req.fail_policy)
+    
+    
+    def update_fail_policy(self, fail_policy):
+        
+        if not fail_policy:
+            return False
+        
+        try:
+            for node in self.tmap2["nodes"]:
+                for edge in node["node"]["edges"]:
+                    edge["fail_policy"] = fail_policy
+                        
             self.update()
             self.write_topological_map(self.filename)
             return True

--- a/topological_navigation_msgs/CMakeLists.txt
+++ b/topological_navigation_msgs/CMakeLists.txt
@@ -37,6 +37,7 @@ add_service_files(
   EvaluateNode.srv
   EvaluateEdge.srv
   AddDatum.srv
+  UpdateFailPolicy.srv
 )
 
 

--- a/topological_navigation_msgs/srv/UpdateEdge.srv
+++ b/topological_navigation_msgs/srv/UpdateEdge.srv
@@ -2,6 +2,7 @@ string edge_id
 string action_name
 string action_type    # e.g. move_base_msgs/MoveBaseGoal
 string goal           # json string setting the args of the goal
+string fail_policy
 bool not_fluid        # if true then the robot must get to the exact pose of the edge's destination node even if it is an intermediate node
 ---
 bool success

--- a/topological_navigation_msgs/srv/UpdateFailPolicy.srv
+++ b/topological_navigation_msgs/srv/UpdateFailPolicy.srv
@@ -1,0 +1,3 @@
+string fail_policy
+---
+bool success


### PR DESCRIPTION
- Service `/topological_map_manager2/update_edge` now has field for updating the edge's fail policy.
- New service `/topological_map_manager2/update_fail_policy` for updating the fail policy of every edge in the map.