### PR TITLE
working version of a "quick&dirty" implementation of the fail_policy

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -863,7 +863,7 @@ class TopologicalNavServer(object):
                         recovering = True
                     elif rec_action[0] == "replan":
                         # rospy.loginfo(">>> PLAN ROUTE {}, {}, {}".format(origin_node["node"]["name"], target, destination_node["node"]["name"]))
-                        _route = self.rsearch.search_route(origin_node["node"]["name"], target, avoid_nodes=[destination_node["node"]["name"]])
+                        _route = self.rsearch.search_route(origin_node["node"]["name"], target, avoid_edges=[edge["edge_id"]])
                         # rospy.loginfo(">>> RESULT {}".format(_route))
                         _route = self.enforce_navigable_route(_route, target)
                         # rospy.loginfo(">>> enforced navigable {}".format(_route))

--- a/topological_navigation/src/topological_navigation/route_search2.py
+++ b/topological_navigation/src/topological_navigation/route_search2.py
@@ -45,13 +45,13 @@ class TopologicalRouteSearch2(object):
                 self.children[name].append(item)
 
 
-    def search_route(self, origin, target):
+    def search_route(self, origin, target, avoid_nodes=[]):
         """
         This function searches the route to reach the goal
         """
         route = NavRoute()
 
-        if origin == "none" or target == "none" or origin == target:
+        if origin == "none" or target == "none" or origin == target or target in avoid_nodes:
             return route
 
         goal = self.get_node_from_tmap2(target)
@@ -66,9 +66,14 @@ class TopologicalRouteSearch2(object):
         cen = orig # currently expanded node
         children = self.get_connected_nodes_tmap2(cen) # nodes current node is connected to
 
+        # remove the nodes we want to avoid
+        for _node in avoid_nodes:
+            if _node in children:
+                children.remove(_node)
+
         not_goal=True
         route_found=False
-        while not_goal :
+        while not_goal:
             if target in children:
                 not_goal=False
                 route_found=True
@@ -119,6 +124,10 @@ class TopologicalRouteSearch2(object):
                     cen =  self.get_node_from_tmap2(nte.name)
                     expanded.append(nte)
                     children = self.get_connected_nodes_tmap2(cen)
+                    # remove the nodes we want to avoid
+                    for _node in avoid_nodes:
+                        if _node in children:
+                            children.remove(_node)
                 else:
                     not_goal=False
                     route_found=False

--- a/topological_navigation/src/topological_navigation/route_search2.py
+++ b/topological_navigation/src/topological_navigation/route_search2.py
@@ -45,13 +45,13 @@ class TopologicalRouteSearch2(object):
                 self.children[name].append(item)
 
 
-    def search_route(self, origin, target, avoid_nodes=[]):
+    def search_route(self, origin, target, avoid_edges=[]):
         """
         This function searches the route to reach the goal
         """
         route = NavRoute()
 
-        if origin == "none" or target == "none" or origin == target or target in avoid_nodes:
+        if origin == "none" or target == "none" or origin == target:
             return route
 
         goal = self.get_node_from_tmap2(target)
@@ -66,10 +66,18 @@ class TopologicalRouteSearch2(object):
         cen = orig # currently expanded node
         children = self.get_connected_nodes_tmap2(cen) # nodes current node is connected to
 
+        # get the pair of node (orig-dest) of the edges we need to avoid
+        avoid_pairs = []
+        for _edge in avoid_edges:
+            avoid_pairs.append(
+                get_node_names_from_edge_id_2(self.top_map, _edge)
+            )
+
         # remove the nodes we want to avoid
-        for _node in avoid_nodes:
-            if _node in children:
-                children.remove(_node)
+        if origin in [p[0] for p in avoid_pairs]:
+            for (_, _dest) in avoid_pairs:
+                if _dest in children:
+                    children.remove(_dest)
 
         not_goal=True
         route_found=False
@@ -125,9 +133,10 @@ class TopologicalRouteSearch2(object):
                     expanded.append(nte)
                     children = self.get_connected_nodes_tmap2(cen)
                     # remove the nodes we want to avoid
-                    for _node in avoid_nodes:
-                        if _node in children:
-                            children.remove(_node)
+                    if nte.name in [p[0] for p in avoid_pairs]:
+                        for (_, _dest) in avoid_pairs:
+                            if _dest in children:
+                                children.remove(_dest)
                 else:
                     not_goal=False
                     route_found=False


### PR DESCRIPTION
Implements the following fail policy actions:
- **retry_N** with N the number of retries, tries again to execute the same action;
- **wait_S_N** with S the number of seconds and N the number of waits, wait action;
- **replan**, generates a new plan which does not pass through the same edge where the fail occurred;
- **fail**, fails the entire plan.
