### PR TITLE
A few final things.

### DIFF
--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -28,11 +28,17 @@ def pose_dist(pose1, pose2):
 class map_manager_2(object):
     
     
-    def __init__(self):
+    def __init__(self, advertise_srvs=True):
         
         self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
         if not os.path.exists(self.cache_dir):
             os.mkdir(self.cache_dir)
+        
+        if advertise_srvs:
+            self.advertise()
+        
+    
+    def advertise(self):
         
         # Services that retrieve information from the map
         self.get_map_srv=rospy.Service('/topological_map_manager2/get_topological_map', Trigger, self.get_topological_map_cb)
@@ -1182,7 +1188,7 @@ class map_manager_2(object):
 
         except Exception as e:
             rospy.logerr(
-                "Cannot convert map to the old format. The conversion requires all fields of the old format map to be set.")
+                "Cannot convert map to the legacy format. The conversion requires all fields of the legacy map to be set.")
             points = topological_navigation_msgs.msg.TopologicalMap()
 
         return points

--- a/topological_navigation_msgs/srv/UpdateFailPolicy.srv
+++ b/topological_navigation_msgs/srv/UpdateFailPolicy.srv
@@ -1,3 +1,11 @@
 string fail_policy
 ---
 bool success
+
+
+# "retry_N"   with N the number of retries, tries again to execute the same action
+# "wait_S_N"  with S the number of seconds and N the number of waits, wait action
+# "replan_N"  with N the number of replans, generates a new plan which does not pass through the same edge where the fail occurred
+# "fail"      fails the entire plan
+
+# can combine fail policy actions e.g "replan_2, fail"

--- a/topological_utils/scripts/edge_reconf_groups_to_tmap2.py
+++ b/topological_utils/scripts/edge_reconf_groups_to_tmap2.py
@@ -16,7 +16,7 @@ def load_yaml(filename):
     
 def edge_groups_to_tmap2(f_tmap2, groups, group_names):
     
-    mm2 = map_manager_2()
+    mm2 = map_manager_2(advertise_srvs=False)
     mm2.init_map(filename=f_tmap2)
 
     for name in group_names:


### PR DESCRIPTION
- Set `advertise_srvs` arg to False when initialising the map manager 2 allows other scripts/nodes to use its functions without advertising 20+ services.
- Descriptions of fail policy actions added to `UpdateFailPolicy.srv`.
- Tidying.