### PR TITLE
Fixes toponav breaking when move base is not being used

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -99,10 +99,6 @@ class TopologicalNavServer(object):
         self.move_base_name = rospy.get_param("~move_base_name", "move_base")
         if not self.move_base_name in self.move_base_actions:
             self.move_base_actions.append(self.move_base_name)
-            
-        self.move_base_planner = rospy.get_param("~move_base_planner", "move_base/DWAPlannerROS")
-        if not self.move_base_planner.split("/")[-1] in DYNPARAM_MAPPING:
-            DYNPARAM_MAPPING[self.move_base_planner.split("/")[-1]] = {}
         
         self.stats_pub = rospy.Publisher("topological_navigation/Statistics", NavStatistics, queue_size=10)
         self.edge_pub = rospy.Publisher("topological_navigation/Edge", CurrentEdge, queue_size=10)
@@ -191,6 +187,9 @@ class TopologicalNavServer(object):
     def init_reconfigure(self):
         
         self.move_base_planner = rospy.get_param("~move_base_planner", "move_base/DWAPlannerROS")
+        if not self.move_base_planner.split("/")[-1] in DYNPARAM_MAPPING:
+            DYNPARAM_MAPPING[self.move_base_planner.split("/")[-1]] = {}
+        
         rospy.loginfo("Creating reconfigure client for {}".format(self.move_base_planner))
         self.rcnfclient = dynamic_reconfigure.client.Client(self.move_base_planner)
         self.init_dynparams = self.rcnfclient.get_configuration()

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -99,6 +99,10 @@ class TopologicalNavServer(object):
         self.move_base_name = rospy.get_param("~move_base_name", "move_base")
         if not self.move_base_name in self.move_base_actions:
             self.move_base_actions.append(self.move_base_name)
+            
+        self.move_base_planner = rospy.get_param("~move_base_planner", "move_base/DWAPlannerROS")
+        if not self.move_base_planner.split("/")[-1] in DYNPARAM_MAPPING:
+            DYNPARAM_MAPPING[self.move_base_planner.split("/")[-1]] = {}
         
         self.stats_pub = rospy.Publisher("topological_navigation/Statistics", NavStatistics, queue_size=10)
         self.edge_pub = rospy.Publisher("topological_navigation/Edge", CurrentEdge, queue_size=10)

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -210,7 +210,7 @@ class TopologicalNavServer(object):
             cytol = 6.283
 
         params = {"yaw_goal_tolerance": cytol, "xy_goal_tolerance": cxygtol}
-        rospy.loginfo("Reconfiguring %s with %s" % (self.move_base_name, params))
+        rospy.loginfo("Reconfiguring %s with %s" % (self.move_base_planner, params))
         print("Intermediate: {}".format(intermediate))
         self.reconfigure_movebase_params(params)
         


### PR DESCRIPTION
Resolves https://github.com/LCAS/topological_navigation/issues/120
You will need to set the param `move_base_planner` to an action that is being used e.g. `row_traversal`
Merge with https://github.com/SAGARobotics/SagaApps/pull/427 and https://github.com/LCAS/RASberry/pull/1181