### PR TITLE
bug when adding edge and destination node does not exist

### DIFF
--- a/topological_navigation/src/topological_navigation/manager.py
+++ b/topological_navigation/src/topological_navigation/manager.py
@@ -476,7 +476,16 @@ class map_manager(object):
         #print query, query_meta
         available = msg_store.query(topological_navigation_msgs.msg.TopologicalNode._type, query, query_meta)
         #print len(available)
-        if len(available) == 1 :
+
+        #Checking also that the destination node exists
+        query = {"name" : de_waypoint, "pointset": self.nodes.name}
+        query_meta = {}
+        query_meta["pointset"] = self.nodes.name
+        query_meta["map"] = self.nodes.map
+        dest_available = msg_store.query(topological_navigation_msgs.msg.TopologicalNode._type, query, query_meta)    
+
+
+        if len(available) == 1 and len(dest_available) == 1:
             eids = []
             for i in available[0][0].edges :
                 eids.append(i.edge_id)


### PR DESCRIPTION
the edge creation function only checks if the origin nodes exists. if the origin exists and the destination node doesn't, the edge is created anyway, creating errors later as there is a node missing.