### PR TITLE
New param `topological_navigation/move_base_goal` sets the goal type …

### DIFF
--- a/topological_navigation/config/move_base_goal.yaml
+++ b/topological_navigation/config/move_base_goal.yaml
@@ -1,0 +1,7 @@
+topological_navigation/move_base_goal:
+  action_type: move_base_msgs/MoveBaseGoal
+  goal:
+    target_pose:
+      header:
+        frame_id: $node.parent_frame
+      pose: $node.pose

--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -33,6 +33,9 @@
   <!-- ### TOPOLOGICAL NAVIGATION ARGS ### -->
   <!-- The action being used for move_base -->
   <arg name="move_base_name" default="move_base"/>
+  <!-- The goal being used by the move_base_name action. Defaults to a move base type goal if this arg is not set. -->
+  <arg name="move_base_goal" default="$(find topological_navigation)/config/move_base_goal.yaml"/>
+  <rosparam command="load" file="$(arg move_base_goal)"/>
   <!-- The planner being used by move_base. STRANDS systems tend to use DWAPlannerROS Jackal and HSR TrajectoryPlannerROS.  -->
   <arg name="move_base_planner" default="move_base/DWAPlannerROS"/>
   <!-- If the action of the current or next edge in the route is not in this list then the robot must get to the exact pose of the current edge's destination node. -->

--- a/topological_navigation/launch/topological_navigation.launch
+++ b/topological_navigation/launch/topological_navigation.launch
@@ -33,7 +33,7 @@
   <!-- ### TOPOLOGICAL NAVIGATION ARGS ### -->
   <!-- The action being used for move_base -->
   <arg name="move_base_name" default="move_base"/>
-  <!-- The goal being used by the move_base_name action. Defaults to a move base type goal if this arg is not set. -->
+  <!-- The goal being used by the move_base_name action. If not set defaults to the goal used by the action in the map else a move base type goal. -->
   <arg name="move_base_goal" default="$(find topological_navigation)/config/move_base_goal.yaml"/>
   <rosparam command="load" file="$(arg move_base_goal)"/>
   <!-- The planner being used by move_base. STRANDS systems tend to use DWAPlannerROS Jackal and HSR TrajectoryPlannerROS.  -->

--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -88,7 +88,6 @@ class TopologicalNavServer(object):
             "han_vc_junction",
         ]
 
-        self.needed_actions = []
         self.move_base_actions = rospy.get_param("~move_base_actions", move_base_actions)
 
         # what service are we using as move_base?
@@ -262,6 +261,9 @@ class TopologicalNavServer(object):
                         move_base_goal["action_type"] = edge["action_type"]
                         move_base_goal["goal"] = edge["goal"]
                         break
+                else:
+                    continue
+                break
 
         if not move_base_goal:
             move_base_goal["action_type"] = "move_base_msgs/MoveBaseGoal"
@@ -274,7 +276,7 @@ class TopologicalNavServer(object):
         self.move_base_edge["action_type"] = move_base_goal["action_type"]
         self.move_base_edge["goal"] = move_base_goal["goal"]
 
-        rospy.loginfo("Move base goal: {}".format(move_base_goal["action_type"]))
+        rospy.loginfo("Move Base Goal set to {}".format(move_base_goal["action_type"]))
 
 
     def executeCallback(self, goal):

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -932,13 +932,14 @@ class map_manager_2(object):
             msg = ""
             for edge in the_node["node"]["edges"]:
                 if edge["edge_id"] == edge_id:
+
                     config = copy.deepcopy(edge["config"])
                     config = [i for i in config if not (i["namespace"] == namespace and i["name"] == name)]
 
                     edge["config"] = config
                     msg = "edge action is {} and edge config is {}".format(edge["action"], edge["config"])
-            self.tmap2["nodes"][index] = the_node
 
+            self.tmap2["nodes"][index] = the_node
             self.update()
             if self.auto_write:
                 self.write_topological_map(self.filename)

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -186,9 +186,6 @@ class map_manager_2(object):
             return
         
         self.loaded = True
-
-        if check:
-            self.map_check()
             
         self.name = self.tmap2["name"]
         self.metric_map = self.tmap2["metric_map"]
@@ -202,6 +199,9 @@ class map_manager_2(object):
         rospy.set_param('topological_map2_path', os.path.split(self.filename)[0])
         
         rospy.loginfo("Done")
+
+        if check:
+            self.map_check()
 
         if self.cache_maps:
             rospy.loginfo("Caching the map...")
@@ -886,19 +886,23 @@ class map_manager_2(object):
         node_name, _ = get_node_names_from_edge_id_2(self.tmap2, edge_id)
         num_available, index = self.get_instances_of_node(node_name)
         
-        new_param = {"namespace":namespace, "name":name, "value":value}
+        param = {"namespace":namespace, "name":name, "value":value}
+
         if num_available == 1:
             the_node = copy.deepcopy(self.tmap2["nodes"][index])
             msg = ""
             for edge in the_node["node"]["edges"]:
                 if edge["edge_id"] == edge_id:
-                    if "config" not in edge:
-                        edge["config"] = []
-                    if new_param not in edge["config"]:
-                        rospy.loginfo("Adding param {} to edge {}".format(new_param, edge["edge_id"]))
-                        edge["config"].append(new_param)
+
+                    config = copy.deepcopy(edge["config"])
+                    config = [i for i in config if not (i["namespace"] == param["namespace"] and i["name"] == param["name"])]
+
+                    rospy.loginfo("Adding param {} to edge {}".format(param, edge["edge_id"]))
+                    config.append(param)
+                    edge["config"] = config
+
                     msg = "edge action is {} and edge config is {}".format(edge["action"], edge["config"])
-            
+
             self.tmap2["nodes"][index] = the_node
             if update:
                 self.update()
@@ -928,16 +932,13 @@ class map_manager_2(object):
             msg = ""
             for edge in the_node["node"]["edges"]:
                 if edge["edge_id"] == edge_id:
-                    if "config" in edge:
-                        params_new = []
-                        for param in copy.deepcopy(edge["config"]):
-                            if param["namespace"] == namespace and param["name"] == name:
-                                continue
-                            else:
-                                params_new.append(param)
-                        edge["config"] = params_new
-                        msg = "edge action is {} and edge config is {}".format(edge["action"], edge["config"])
+                    config = copy.deepcopy(edge["config"])
+                    config = [i for i in config if not (i["namespace"] == namespace and i["name"] == name)]
+
+                    edge["config"] = config
+                    msg = "edge action is {} and edge config is {}".format(edge["action"], edge["config"])
             self.tmap2["nodes"][index] = the_node
+
             self.update()
             if self.auto_write:
                 self.write_topological_map(self.filename)


### PR DESCRIPTION
…of the default action `move_base_name`.

If not set defaults to  the goal used by the action if it occurs in the tmap else a standard move base type goal..
This will stop toponav breaking if the `move_base_name` action does not use move base type goals.
Also an improvement to the add/remove edge param srvs.
Removed unused imports