### PR TITLE
Auto set goal when adding an edge to the topological map

### DIFF
--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -595,7 +595,10 @@ class map_manager_2(object):
                     package = action_type.split("/")[0]
                     goal_def = action_type.split("/")[1]
     
-                    _file = "{}/config/{}.yaml".format(rospkg.RosPack().get_path(package), goal_def)
+                    _file = rospy.get_param("~" + action_type, "")
+                    if not _file:
+                        _file = "{}/config/{}.yaml".format(rospkg.RosPack().get_path(package), goal_def)
+
                     with open(_file, "r") as f:
                         goal = yaml.safe_load(f)
                 except:

--- a/topological_navigation/src/topological_navigation/manager2.py
+++ b/topological_navigation/src/topological_navigation/manager2.py
@@ -9,7 +9,7 @@ from __future__ import division
 import rospy, tf2_ros, math
 import yaml, datetime, json
 import re, uuid, copy, os
-import multiprocessing
+import multiprocessing, rospkg
 
 from topological_navigation_msgs.msg import *
 import topological_navigation_msgs.srv
@@ -26,12 +26,13 @@ from topological_navigation.tmap_utils import get_node_names_from_edge_id_2
 def pose_dist(pose1, pose2):
     return math.sqrt((pose1["position"]["x"] - pose2["position"]["x"])**2 + (pose1["position"]["y"] - pose2["position"]["y"])**2)
 
-
 class NoAliasDumper(yaml.SafeDumper):
     def ignore_aliases(self, data):
         return True
+#########################################################################################################
 
 
+#########################################################################################################
 class map_manager_2(object):
     
     
@@ -46,6 +47,11 @@ class map_manager_2(object):
         self.cache_dir = os.path.join(os.path.expanduser("~"), ".ros", "topological_maps")     
         if not os.path.exists(self.cache_dir):
             os.mkdir(self.cache_dir)
+
+        self.goal_mappings = {}        
+        mb_goal_f = "{}/config/{}".format(rospkg.RosPack().get_path("topological_navigation"), "move_base_goal.yaml")
+        with open(mb_goal_f, "r") as f:
+            self.move_base_goal = yaml.safe_load(f)["topological_navigation/move_base_goal"]
         
         if advertise_srvs:
             self.advertise()
@@ -504,11 +510,11 @@ class map_manager_2(object):
         """
         Adds an edge to a topological node
         """
-        return self.add_edge(req.origin, req.destination, req.action, req.edge_id)
+        return self.add_edge(req.origin, req.destination, req.action, req.action_type, req.edge_id)
     
     
-    def add_edge(self, origin, destination, action, edge_id, update=True, write_map=True):
-        
+    def add_edge(self, origin, destination, action, action_type, edge_id, update=True, write_map=True):
+
         rospy.loginfo("Adding Edge from {} to {} using {}".format(origin, destination, action))
         
         num_available, index = self.get_instances_of_node(origin)
@@ -531,7 +537,7 @@ class map_manager_2(object):
             else:
                 eid=edge_id
                 
-            self.add_edge_to_node(origin, destination, action, eid)
+            self.add_edge_to_node(origin, destination, action, eid, action_type=action_type)
             
             if update:
                 self.update()
@@ -543,8 +549,8 @@ class map_manager_2(object):
             return False
         
         
-    def add_edge_to_node(self, origin, destination, action="move_base", edge_id="default", config=[],
-                         recovery_behaviours_config="", action_type="move_base_msgs/MoveBaseGoal", goal="default", fail_policy="fail", 
+    def add_edge_to_node(self, origin, destination, action="", edge_id="default", config=[],
+                         recovery_behaviours_config="", action_type="", goal=None, fail_policy="fail", 
                          restrictions_planning="True", restrictions_runtime="True", fluid_navigation=True):
         
         edge = {}
@@ -559,20 +565,14 @@ class map_manager_2(object):
         edge["config"] = config
         edge["recovery_behaviours_config"] = recovery_behaviours_config
         
-        if action_type == "default":
-            edge["action_type"] = self.set_action_type(action)
-        else:
-            edge["action_type"] = action_type
-            
-        if goal == "default":
-            edge["goal"] = {}
-            edge["goal"]["target_pose"] = {}
-            edge["goal"]["target_pose"]["pose"] = "$node.pose"
-            edge["goal"]["target_pose"]["header"] = {}
-            edge["goal"]["target_pose"]["header"]["frame_id"] = "$node.parent_frame"
-        else:
-            edge["goal"] = goal
-            
+        if not action_type:
+            action_type = "move_base_msgs/MoveBaseGoal"
+        
+        the_action_type, the_goal = self.set_goal(action, action_type, goal)
+        
+        edge["action_type"] = the_action_type
+        edge["goal"] = the_goal
+        
         edge["fail_policy"] = fail_policy
         edge["restrictions_planning"] = restrictions_planning
         edge["restrictions_runtime"] = restrictions_runtime
@@ -582,7 +582,31 @@ class map_manager_2(object):
             if node["node"]["name"] == origin:
                 node["node"]["edges"].append(edge)
                 
+    
+    def set_goal(self, action, action_type, _goal=None):
+        
+        if action in self.goal_mappings and action_type == self.goal_mappings[action]["action_type"]:
+            goal = self.goal_mappings[action]["goal"]
+        else:
+            if _goal is not None:
+                goal = _goal
+            else:
+                try:
+                    package = action_type.split("/")[0]
+                    goal_def = action_type.split("/")[1]
+    
+                    _file = "{}/config/{}.yaml".format(rospkg.RosPack().get_path(package), goal_def)
+                    with open(_file, "r") as f:
+                        goal = yaml.safe_load(f)
+                except:
+                    action_type = self.move_base_goal["action_type"]
+                    goal = self.move_base_goal["goal"]
                 
+            self.goal_mappings[action] = {"action_type": action_type, "goal": goal}
+            
+        return action_type, goal
+
+
     def set_action_type(self, action):
         
         package = action + "_msgs"
@@ -591,8 +615,8 @@ class map_manager_2(object):
         action_type = package + "/" + goal_type
             
         return action_type
-                
-                
+
+
     def remove_node_cb(self, req):
         """
         Removes a node from the topological map
@@ -1091,6 +1115,10 @@ class map_manager_2(object):
                         edge["action_type"] = action_type
                     if goal:
                         edge["goal"] = json.loads(goal)
+                    elif action_type and not goal:
+                        _action_type, _goal = self.set_goal(action_name, action_type)
+                        edge["action_type"] = _action_type
+                        edge["goal"] = _goal
                     if fail_policy:
                         edge["fail_policy"] = fail_policy
                     if not_fluid:
@@ -1127,6 +1155,10 @@ class map_manager_2(object):
                         edge["action_type"] = action_type
                     if goal:
                         edge["goal"] = json.loads(goal)
+                    elif action_type and not goal:
+                        _action_type, _goal = self.set_goal(action_name, action_type)
+                        edge["action_type"] = _action_type
+                        edge["goal"] = _goal
                     success = True
         
         if success:
@@ -1270,7 +1302,7 @@ class map_manager_2(object):
     def add_edges(self, data, update=True, write_map=True):
         
         for item in data:
-            success = self.add_edge(item.origin, item.destination, item.action, item.edge_id, update=False, write_map=False)
+            success = self.add_edge(item.origin, item.destination, item.action, item.action_type, item.edge_id, update=False, write_map=False)
             if not success:
                 return False
 

--- a/topological_navigation_msgs/msg/AddEdgeReq.msg
+++ b/topological_navigation_msgs/msg/AddEdgeReq.msg
@@ -1,4 +1,5 @@
 string origin
 string destination
 string action
+string action_type
 string edge_id

--- a/topological_navigation_msgs/srv/AddEdge.srv
+++ b/topological_navigation_msgs/srv/AddEdge.srv
@@ -1,6 +1,7 @@
 string origin
 string destination
 string action
+string action_type
 string edge_id
 ---
 bool success

--- a/topological_utils/CMakeLists.txt
+++ b/topological_utils/CMakeLists.txt
@@ -26,7 +26,7 @@ add_service_files(
 )
 generate_messages(
 DEPENDENCIES
-    std_msgs 
+    std_msgs
 )
 catkin_package(
 #  INCLUDE_DIRS include

--- a/topological_utils/config/goal.yaml
+++ b/topological_utils/config/goal.yaml
@@ -1,8 +1,0 @@
-target_pose:
-  header:
-    frame_id: $node.parent_frame
-  pose: $node.pose
-origin_pose:
-  header:
-    frame_id: +node.parent_frame
-  pose: +node.pose

--- a/topological_utils/scripts/goal_converter.py
+++ b/topological_utils/scripts/goal_converter.py
@@ -5,19 +5,12 @@ Created on Thu Apr 29 10:04:30 2021
 @author: Adam Binch (abinch@sagarobotics.com)
 """
 #########################################################################################################
-import sys, os, traceback
-import rospy, yaml, json
+import sys, os, traceback, rospy
 
 from topological_navigation.manager2 import map_manager_2
 
-def load_data_from_yaml(filename):
-    with open(filename, 'r') as f:
-        return yaml.load(f)
 
-
-def convert_goal(root_dir, action, action_type, goal_path):
-    
-    goal = load_data_from_yaml(goal_path)
+def convert_goal(root_dir, action, action_type):
         
     tmap_files = []
     for root, dirs, files in os.walk(root_dir):
@@ -32,7 +25,7 @@ def convert_goal(root_dir, action, action_type, goal_path):
         
         try:
             mm.init_map(filename=f)
-            mm.update_action(action, action_type, json.dumps(goal), update=False, write_map=False)
+            mm.update_action(action, action_type, "", update=False, write_map=False)
             mm.write_topological_map(f)
         except Exception:
             rospy.logerr("Unable to convert goal in {}\n{}".format(f, traceback.format_exc()))
@@ -45,17 +38,16 @@ def convert_goal(root_dir, action, action_type, goal_path):
 #########################################################################################################    
 if __name__ == '__main__' :
     
-    if "-h" in sys.argv or "--help" in sys.argv or len(sys.argv) < 5:
-        print "usage is goal_converter.py root_directory action action_type goal"
+    if "-h" in sys.argv or "--help" in sys.argv or len(sys.argv) < 4:
+        print "usage is goal_converter.py root_directory action action_type"
         sys.exit(1)
     else:
         root_dir = sys.argv[1]
         action = sys.argv[2]
         action_type = sys.argv[3]
-        goal = sys.argv[4]
 
     print("Converting the goal type of {} action to {} for topological maps found in {}".format(action, action_type, root_dir))
 
     rospy.init_node("topological_goal_converter")
-    convert_goal(root_dir, action, action_type, goal)
+    convert_goal(root_dir, action, action_type)
 #########################################################################################################


### PR DESCRIPTION
If a file e.g. `package/config/Goal.yaml` exists then the map manager will automatically set the goal of the action to the goal specified in that file, when the add edge function/service is called with arg `action_type` set to package/Goal. If that arg is not set or the file does not exist then a move base type goal is assumed.