### PR TITLE
Added ros param 'simulation_mode' to 'navigation.py' to allow abstracted navigation between nodes in simulation

### DIFF
--- a/topological_navigation/scripts/navigation.py
+++ b/topological_navigation/scripts/navigation.py
@@ -21,6 +21,8 @@ from topological_navigation.edge_reconfigure_manager import EdgeReconfigureManag
 
 from threading import Lock
 
+simulation_mode = False
+
 # A list of parameters topo nav is allowed to change and their mapping from dwa speak.
 # If not listed then the param is not sent, e.g. TrajectoryPlannerROS doesn't have tolerances.
 DYNPARAM_MAPPING = {
@@ -90,6 +92,11 @@ class TopologicalNavServer(object):
             "han_vc_junction",
         ]
 
+        global simulation_mode
+        simulation_mode = rospy.get_param('~simulation_mode', False)  # Set True if you want to use abstracted navigation (i.e. teleporting between nodes)
+        if simulation_mode:
+            rospy.loginfo("Topological navigation is running in simulation mode")
+        
         self.move_base_actions = rospy.get_param("~move_base_actions", move_base_actions)
 
         # what service are we using as move_base?
@@ -198,9 +205,11 @@ class TopologicalNavServer(object):
             cytol = 6.283
 
         params = {"yaw_goal_tolerance": cytol, "xy_goal_tolerance": cxygtol}
-        rospy.loginfo("Reconfiguring %s with %s" % (self.move_base_planner, params))
+
+        if not simulation_mode:
+            rospy.loginfo("Reconfiguring %s with %s" % (self.move_base_planner, params))
+            self.reconfigure_movebase_params(params)
         print("Intermediate: {}".format(intermediate))
-        self.reconfigure_movebase_params(params)
         
 
     def reconfigure_movebase_params(self, params):
@@ -623,7 +632,8 @@ class TopologicalNavServer(object):
         Targ = target
         self._target = Targ
 
-        self.init_reconfigure()
+        if not simulation_mode:
+            self.init_reconfigure()
 
         rospy.loginfo("%d Nodes on route" % nnodes)
 
@@ -656,7 +666,9 @@ class TopologicalNavServer(object):
     
                 # 5 degrees tolerance
                 params = {"yaw_goal_tolerance": 0.087266}
-                self.reconfigure_movebase_params(params)
+                
+                if not simulation_mode:
+                    self.reconfigure_movebase_params(params)
 
                 self.current_target = Orig
                 nav_ok, inc = self.execute_action(self.move_base_edge, o_node)
@@ -739,7 +751,9 @@ class TopologicalNavServer(object):
             self.edge_reconf_end()
 
             params = {"yaw_goal_tolerance": 0.087266, "xy_goal_tolerance": 0.1}
-            self.reconfigure_movebase_params(params)
+            
+            if not simulation_mode:
+                self.reconfigure_movebase_params(params)
 
             not_fatal = nav_ok
             if self.cancelled:
@@ -775,7 +789,8 @@ class TopologicalNavServer(object):
             if not replanned:
                 rindex = rindex + 1
 
-        self.reset_reconf()
+        if not simulation_mode:
+            self.reset_reconf()
 
         self.navigation_activated = False
 


### PR DESCRIPTION
I have added a ros param, 'simulation_mode', in `navigation.py` that disables move_base reconfigure functions if set to True, with the default value set to False. This allows topological navigation to work with my ROS package [move_base_abstract](https://github.com/laurencejbelliott/move_base_abstract/), which is a drop-in replacement for move_base for abstracted navigation for faster simulation. If 'simulation_mode' is set to True, and move_base_abstract's actionserver is running, a robot will "teleport", by its pose being set in Gazebo, to its goal pose, from its current pose, after a `rospy.sleep` time delay equal to a constant average robot speed (m/s) * distance (m).