### PR TITLE
parameters shouldn't use ~

### DIFF
--- a/topological_navigation/topological_navigation/scripts/localisation2.py
+++ b/topological_navigation/topological_navigation/scripts/localisation2.py
@@ -30,13 +30,13 @@ class TopologicalNavLoc(rclpy.node.Node):
     def __init__(self, name, wtags):
         super().__init__(name)
         
-        self.declare_parameter('~LocalisationThrottle', rclpy.Parameter.Type.INTEGER) 
-        self.declare_parameter('~OnlyLatched', rclpy.Parameter.Type.BOOL) 
-        self.declare_parameter('~base_frame', rclpy.Parameter.Type.STRING)
+        self.declare_parameter('LocalisationThrottle', rclpy.Parameter.Type.INTEGER) 
+        self.declare_parameter('OnlyLatched', rclpy.Parameter.Type.BOOL) 
+        self.declare_parameter('base_frame', rclpy.Parameter.Type.STRING)
 
-        self.throttle_val = self.get_parameter_or("~LocalisationThrottle", Parameter('int', Parameter.Type.INTEGER, 3)).value
+        self.throttle_val = self.get_parameter_or("LocalisationThrottle", Parameter('int', Parameter.Type.INTEGER, 3)).value
         self.only_latched = self.get_parameter_or("OnlyLatched", Parameter('bool', Parameter.Type.BOOL, True)).value 
-        self.base_frame = self.get_parameter_or("~base_frame", Parameter('str', Parameter.Type.STRING, "base_link")).value
+        self.base_frame = self.get_parameter_or("base_frame", Parameter('str', Parameter.Type.STRING, "base_link")).value
 
         self.throttle = self.throttle_val
         self.node="Unknown"


### PR DESCRIPTION
This pull request includes changes to the `TopologicalNavLoc` class in the `localisation2.py` script to simplify parameter declarations and usage. The most important change is the removal of the tilde (`~`) prefix from parameter names.

Parameter handling simplification:

* [`topological_navigation/topological_navigation/scripts/localisation2.py`](diffhunk://#diff-26a08ee5ca51f67dae3951e67fa676267651c91699ed482256aafffd2489fed0L33-R39): Removed the tilde (`~`) prefix from parameter names in the `declare_parameter` and `get_parameter_or` methods.