### PR TITLE
Updating the topological map visualization when the map topic gets update.

### DIFF
--- a/topological_navigation/topological_navigation/scripts/visualise_map_ros2.py
+++ b/topological_navigation/topological_navigation/scripts/visualise_map_ros2.py
@@ -23,7 +23,21 @@ from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallb
 from builtin_interfaces.msg import Duration
 from rclpy.task import Future
 import threading
+import yaml
 
+# this ensures that all the poses and translates 
+# are float-type and not int-type as there is an 
+# assertion in ros2 messages (vector3, pose etc.) 
+# for float-type [x,y,z,w] keys.
+class CustomSafeLoader(yaml.SafeLoader):
+    def construct_mapping(self, node, deep=False):
+        mapping = super().construct_mapping(node, deep=deep)
+        for key in ['x', 'y', 'z', 'w']:
+            if key in mapping and isinstance(mapping[key], int):
+                mapping[key] = float(mapping[key])
+        
+        return mapping
+    
 def get_node(nodes_list, name):
     for i in nodes_list:
         if i['node']['name'] == name:
@@ -122,7 +136,7 @@ class TopoMap2Vis(rclpy.node.Node):
         self.get_logger().info("All Done ...")
 
     def topo_map_cb(self, msg):
-        self.topological_map = json.loads(msg.data)
+        self.topological_map =  yaml.load(msg.data, Loader = CustomSafeLoader) 
         self.get_logger().info("{}".format(self.topological_map['name']))
         self._map_received = True  
 

--- a/topological_navigation/topological_navigation/scripts/visualise_map_ros2.py
+++ b/topological_navigation/topological_navigation/scripts/visualise_map_ros2.py
@@ -139,6 +139,7 @@ class TopoMap2Vis(rclpy.node.Node):
         self.topological_map =  yaml.load(msg.data, Loader = CustomSafeLoader) 
         self.get_logger().info("{}".format(self.topological_map['name']))
         self._map_received = True  
+        self.create_map_marker()
 
     def route_cb(self, msg):
         self.clear_route() # clear the last route


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds two things: 

1) Safe custom YAML loaders to load the topological map string into JSON object. The custom loader makes sure that position and orientation values are in `float` instead of `int`. This check is required as JSON stringification converts `x: 0.0` into `x: 0` and Python type cast it into `int` instead of `float`. 

2) Topo map callback function is only used in the initialization. This does not work if the `topological_map_2` topic gets an update / publication. The map visualization method was moved to the topic callback. This allows to get live updates of topological_map from remote such as `fleet monitor`. 

Demo Video: 


https://github.com/user-attachments/assets/0a527f45-0583-4d8f-85f8-b3fed95ddaad



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes._

## [optional] Are there any post deployment tasks we need to perform?
