### PR TITLE
Add cancellation handling in EdgeActionManager during row operations

### DIFF
--- a/topological_navigation/topological_navigation/edge_action_manager2.py
+++ b/topological_navigation/topological_navigation/edge_action_manager2.py
@@ -454,9 +454,10 @@ class EdgeActionManager(rclpy.node.Node):
             
             try: 
                 cancel_future = self.goal_handle.cancel_goal_async()
-                rclpy.spin_until_future_complete(self, cancel_future, timeout_sec=5.0)
+                rclpy.spin_until_future_complete(self, cancel_future, timeout_sec=timeout_secs)
                 self.get_logger().info("Waiting till terminating the current preemption")
-                self.action_status = 5
+                # set to canceled
+                self.action_status = GoalStatus.STATUS_CANCELED
                 self.get_logger().info("The goal cancel error code {} ".format(self.get_goal_cancel_error_msg(cancel_future.result().return_code)))
                 self.robot_current_status = self.ACTIONS.ROBOT_STATUS_NATURAL_STATE
                 self.publish_robot_current_status_msg(self.ACTIONS.NAVIGATE_THROUGH_POSES, self.robot_current_status)
@@ -464,6 +465,13 @@ class EdgeActionManager(rclpy.node.Node):
             except Exception as e:
                 self.get_logger().error("Something wrong with Nav2 Control server {} while preempting {}".format(e, self.action_server_name))
                 return True 
+            finally:
+                # in any case set it to canceled
+                self.action_status = GoalStatus.STATUS_CANCELED
+        else:
+            self.get_logger().warning("There is no client to preempt")
+            self.action_status = GoalStatus.STATUS_CANCELED
+            return True
         
         
     def construct_goal(self, goal_args, destination_node, origin_node):

--- a/topological_navigation/topological_navigation/edge_action_manager2.py
+++ b/topological_navigation/topological_navigation/edge_action_manager2.py
@@ -1234,7 +1234,14 @@ class EdgeActionManager(rclpy.node.Node):
             robot_init_pose = self.current_robot_pose
             
             if inrow_opt.isPlanCalculated():
-                while True:
+                while rclpy.ok():
+                    # Check for cancellation before proceeding with next iteration
+                    if self.action_status == 5: # see https://docs.ros.org/en/jazzy/p/action_msgs/msg/GoalStatus.html
+                        self.get_logger().warn("Row operation cancelled - exiting loop")
+                        self.robot_current_status = self.ACTIONS.ROBOT_STATUS_NATURAL_STATE
+                        self.publish_robot_current_status_msg(self.ACTIONS.ROW_OPERATION, self.robot_current_status)
+                        return False
+                    
                     robot_init_pose = self.current_robot_pose 
                     next_goal, intermediate_pose, get_to_goal = inrow_opt.getNextGoal(robot_init_pose)
                     self.robot_current_status = self.ACTIONS.ROBOT_STATUS_PREPARATION_STATE

--- a/topological_navigation/topological_navigation/edge_action_manager2.py
+++ b/topological_navigation/topological_navigation/edge_action_manager2.py
@@ -1236,8 +1236,8 @@ class EdgeActionManager(rclpy.node.Node):
             if inrow_opt.isPlanCalculated():
                 while rclpy.ok():
                     # Check for cancellation before proceeding with next iteration
-                    if self.action_status == 5: # see https://docs.ros.org/en/jazzy/p/action_msgs/msg/GoalStatus.html
-                        self.get_logger().warn("Row operation cancelled - exiting loop")
+                    if self.action_status == GoalStatus.STATUS_CANCELED:
+                        self.get_logger().warning("Row operation cancelled - exiting loop")
                         self.robot_current_status = self.ACTIONS.ROBOT_STATUS_NATURAL_STATE
                         self.publish_robot_current_status_msg(self.ACTIONS.ROW_OPERATION, self.robot_current_status)
                         return False

--- a/topological_navigation/topological_navigation/edge_action_manager2.py
+++ b/topological_navigation/topological_navigation/edge_action_manager2.py
@@ -464,12 +464,10 @@ class EdgeActionManager(rclpy.node.Node):
                 return True 
             except Exception as e:
                 self.get_logger().error("Something wrong with Nav2 Control server {} while preempting {}".format(e, self.action_server_name))
-                return True 
-            finally:
-                # in any case set it to canceled
                 self.action_status = GoalStatus.STATUS_CANCELED
+                return True
         else:
-            self.get_logger().warning("There is no client to preempt")
+            self.get_logger().warning("There is no client to preempt, setting status to canceled anyway")
             self.action_status = GoalStatus.STATUS_CANCELED
             return True
         

--- a/topological_navigation/topological_navigation/edge_action_manager2.py
+++ b/topological_navigation/topological_navigation/edge_action_manager2.py
@@ -1246,6 +1246,11 @@ class EdgeActionManager(rclpy.node.Node):
                         self.get_logger().warning("Row operation cancelled - exiting loop")
                         self.robot_current_status = self.ACTIONS.ROBOT_STATUS_NATURAL_STATE
                         self.publish_robot_current_status_msg(self.ACTIONS.ROW_OPERATION, self.robot_current_status)
+                        # Allow nav client to fully terminate before returning
+                        try:
+                            rclpy.spin_once(self, executor=self.executor_nav_client, timeout_sec=0.5)
+                        except Exception as e:
+                            self.get_logger().error("Error while spinning once during cancellation: {}".format(e))
                         return False
                     
                     robot_init_pose = self.current_robot_pose 


### PR DESCRIPTION
This pull request improves the robustness and reliability of the `edge_action_manager2.py` module by enhancing how goal cancellation and row operation interruptions are handled. The changes ensure that cancellation status is consistently set and checked, reducing the risk of inconsistent robot states and making the system more responsive to preemption requests.

**Improvements to goal cancellation and preemption:**

* The timeout for spinning until goal cancellation completion in `preempt` is now configurable via the `timeout_secs` parameter, making the function more flexible.
* The `action_status` is now set to `GoalStatus.STATUS_CANCELED` in all code paths in `preempt`, including error and no-client scenarios, ensuring consistent state after preemption attempts.

**Enhancements to row operation interruption:**

* The main loop in `execute_row_operation_action` now checks if the action has been canceled (`GoalStatus.STATUS_CANCELED`) and exits early if so, publishing the appropriate robot status and logging a warning. This makes row operations more responsive to cancellation requests.